### PR TITLE
fix calculations when skipping NaN batches

### DIFF
--- a/tfmplayground/train.py
+++ b/tfmplayground/train.py
@@ -49,15 +49,12 @@ def train(model: NanoTabPFNModel, prior: DataLoader, criterion: nn.CrossEntropyL
     classification_task = isinstance(criterion, nn.CrossEntropyLoss)
     regression_task = not classification_task
 
-    assert prior.num_steps % accumulate_gradients == 0, 'num_steps must be divisible by accumulate_gradients'
-
     try:
         for epoch in range(ckpt['epoch'] + 1 if ckpt else 1, epochs + 1):
             epoch_start_time = time.time()
             model.train()  # Turn on the train mode
             optimizer.train()
             total_loss = 0.
-            num_valid_data = 0
             num_accumulated = 0
             for _, full_data in enumerate(prior):
                 single_eval_pos = full_data['single_eval_pos']
@@ -65,7 +62,6 @@ def train(model: NanoTabPFNModel, prior: DataLoader, criterion: nn.CrossEntropyL
                         full_data['y'][:, :single_eval_pos].to(device))
                 if (torch.isnan(data[0]).any() or torch.isnan(data[1]).any()):
                     continue
-                num_valid_data += 1
                 targets = full_data['target_y'].to(device)
 
                 if regression_task:
@@ -99,7 +95,7 @@ def train(model: NanoTabPFNModel, prior: DataLoader, criterion: nn.CrossEntropyL
                 optimizer.zero_grad()
 
             end_time = time.time()
-            mean_loss = total_loss / max(num_valid_data, 1)
+            mean_loss = total_loss / max(num_accumulated, 1)
             model.eval()
             optimizer.eval()
 

--- a/tfmplayground/train.py
+++ b/tfmplayground/train.py
@@ -90,7 +90,7 @@ def train(model: NanoTabPFNModel, prior: DataLoader, criterion: nn.CrossEntropyL
                 if num_accumulated % accumulate_gradients == 0:
                     torch.nn.utils.clip_grad_norm_(model.parameters(), 1.)
                     optimizer.step()
-                    optimizer.zero_grad()
+                    optimizer.zero_grad(set_to_none=True)
 
             if num_accumulated % accumulate_gradients != 0:
                 remainder = num_accumulated % accumulate_gradients
@@ -100,7 +100,7 @@ def train(model: NanoTabPFNModel, prior: DataLoader, criterion: nn.CrossEntropyL
                         param.grad.mul_(scale)
                 torch.nn.utils.clip_grad_norm_(model.parameters(), 1.)
                 optimizer.step()
-                optimizer.zero_grad()
+                optimizer.zero_grad(set_to_none=True)
 
             end_time = time.time()
             mean_loss = total_loss / max(num_accumulated, 1)

--- a/tfmplayground/train.py
+++ b/tfmplayground/train.py
@@ -79,10 +79,11 @@ def train(model: NanoTabPFNModel, prior: DataLoader, criterion: nn.CrossEntropyL
                     output = output.view(-1, output.shape[-1])
 
                 losses = criterion(output, targets)
-                loss = losses.mean() / accumulate_gradients
+                batch_loss = losses.mean()
+                loss = batch_loss / accumulate_gradients
                 loss.backward()
                 num_accumulated += 1
-                total_loss += loss.cpu().detach().item() * accumulate_gradients
+                total_loss += batch_loss.cpu().detach().item()
 
                 if num_accumulated % accumulate_gradients == 0:
                     torch.nn.utils.clip_grad_norm_(model.parameters(), 1.)

--- a/tfmplayground/train.py
+++ b/tfmplayground/train.py
@@ -57,12 +57,14 @@ def train(model: NanoTabPFNModel, prior: DataLoader, criterion: nn.CrossEntropyL
             model.train()  # Turn on the train mode
             optimizer.train()
             total_loss = 0.
+            num_valid_data = 0
             for i, full_data in enumerate(prior):
                 single_eval_pos = full_data['single_eval_pos']
                 data = (full_data['x'].to(device),
                         full_data['y'][:, :single_eval_pos].to(device))
                 if (torch.isnan(data[0]).any() or torch.isnan(data[1]).any()):
                     continue
+                num_valid_data += 1
                 targets = full_data['target_y'].to(device)
 
                 if regression_task:
@@ -90,7 +92,7 @@ def train(model: NanoTabPFNModel, prior: DataLoader, criterion: nn.CrossEntropyL
                     optimizer.zero_grad()
 
             end_time = time.time()
-            mean_loss = total_loss / len(prior)
+            mean_loss = total_loss / max(num_valid_data, 1)
             model.eval()
             optimizer.eval()
 

--- a/tfmplayground/train.py
+++ b/tfmplayground/train.py
@@ -93,6 +93,11 @@ def train(model: NanoTabPFNModel, prior: DataLoader, criterion: nn.CrossEntropyL
                     optimizer.zero_grad()
 
             if num_accumulated % accumulate_gradients != 0:
+                remainder = num_accumulated % accumulate_gradients
+                scale = accumulate_gradients / remainder
+                for param in model.parameters():
+                    if param.grad is not None:
+                        param.grad.mul_(scale)
                 torch.nn.utils.clip_grad_norm_(model.parameters(), 1.)
                 optimizer.step()
                 optimizer.zero_grad()

--- a/tfmplayground/train.py
+++ b/tfmplayground/train.py
@@ -59,21 +59,20 @@ def train(model: NanoTabPFNModel, prior: DataLoader, criterion: nn.CrossEntropyL
             total_loss = 0.
             num_accumulated = 0
             for _, full_data in enumerate(prior):
-                single_eval_pos = full_data['single_eval_pos']
-                data = (full_data['x'].to(device),
-                        full_data['y'][:, :single_eval_pos].to(device))
-                if (torch.isnan(data[0]).any() or torch.isnan(data[1]).any()):
+                sep = full_data['single_eval_pos']
+                x = full_data['x'].to(device)
+                y = full_data['y'][:, :sep].to(device)
+                targets = full_data['target_y'][:, sep:].to(device)
+
+                if (torch.isnan(x).any() or torch.isnan(y).any()):
                     continue
-                targets = full_data['target_y'].to(device)
 
                 if regression_task:
-                    y_mean = data[1].mean(dim=1, keepdim=True)
-                    y_std = data[1].std(dim=1, keepdim=True) + 1e-8
-                    y_norm = (data[1] - y_mean) / y_std
-                    data = (data[0], y_norm)
+                    y_mean = y.mean(dim=1, keepdim=True)
+                    y_std = y.std(dim=1, keepdim=True) + 1e-8
+                    y = (y - y_mean) / y_std
 
-                output = model(data, single_eval_pos=single_eval_pos)
-                targets = targets[:, single_eval_pos:]
+                output = model((x, y), single_eval_pos=sep)
                 if regression_task:
                     targets = (targets - y_mean) / y_std
                 if classification_task:

--- a/tfmplayground/train.py
+++ b/tfmplayground/train.py
@@ -49,6 +49,8 @@ def train(model: NanoTabPFNModel, prior: DataLoader, criterion: nn.CrossEntropyL
     classification_task = isinstance(criterion, nn.CrossEntropyLoss)
     regression_task = not classification_task
 
+    assert accumulate_gradients > 0, 'accumulate_gradients must be > 0'
+
     try:
         for epoch in range(ckpt['epoch'] + 1 if ckpt else 1, epochs + 1):
             epoch_start_time = time.time()

--- a/tfmplayground/train.py
+++ b/tfmplayground/train.py
@@ -58,7 +58,8 @@ def train(model: NanoTabPFNModel, prior: DataLoader, criterion: nn.CrossEntropyL
             optimizer.train()
             total_loss = 0.
             num_valid_data = 0
-            for i, full_data in enumerate(prior):
+            num_accumulated = 0
+            for _, full_data in enumerate(prior):
                 single_eval_pos = full_data['single_eval_pos']
                 data = (full_data['x'].to(device),
                         full_data['y'][:, :single_eval_pos].to(device))
@@ -84,12 +85,18 @@ def train(model: NanoTabPFNModel, prior: DataLoader, criterion: nn.CrossEntropyL
                 losses = criterion(output, targets)
                 loss = losses.mean() / accumulate_gradients
                 loss.backward()
+                num_accumulated += 1
                 total_loss += loss.cpu().detach().item() * accumulate_gradients
 
-                if (i + 1) % accumulate_gradients == 0:
+                if num_accumulated % accumulate_gradients == 0:
                     torch.nn.utils.clip_grad_norm_(model.parameters(), 1.)
                     optimizer.step()
                     optimizer.zero_grad()
+
+            if num_accumulated % accumulate_gradients != 0:
+                torch.nn.utils.clip_grad_norm_(model.parameters(), 1.)
+                optimizer.step()
+                optimizer.zero_grad()
 
             end_time = time.time()
             mean_loss = total_loss / max(num_valid_data, 1)


### PR DESCRIPTION
Because of the `continue` at line 65, batches containing NaNs are skipped. This led to loss averaging and gradient accumulation not being fully correct, since skipped batches were still implicitly counted.

This was noticed while timing my speedrunning script and inspecting skipped batches.

Integration into the TFM playground hasn’t been thoroughly tested, but the logic should be correct.
