### PR TITLE
Fix NaN predictions caused by incorrect sequence length extraction in 3-argument forward pass

### DIFF
--- a/tfmplayground/model.py
+++ b/tfmplayground/model.py
@@ -51,7 +51,7 @@ class NanoTabPFNModel(nn.Module):
             x = args[0]
             if args[2] is not None:
                 x = torch.cat((x, args[2]), dim=1)
-            return self._forward((x, args[1]), single_eval_pos=len(args[0]), **kwargs)
+            return self._forward((x, args[1]), single_eval_pos=args[0].shape[1], **kwargs)
         elif len(args) == 1 and isinstance(args, tuple):
             # case model((x,y), single_eval_pos=None)
             return self._forward(*args, **kwargs)


### PR DESCRIPTION
**The bug:**
When using the model(X_train, y_train, X_test) interface, the single_eval_pos was being extracted using len(args[0]). Because args[0] is a 3D PyTorch tensor of shape (batch_size, num_train_datapoints, num_features), len() incorrectly returns the batch_size (usually 1 during single-dataset evaluation) rather than the actual sequence length. This caused NaN predictions during inference because the model subsequently tried to calculate the standard deviation of a single data point.

**The Fix:**
Changed len(args[0]) to args[0].shape[1] in NanoTabPFNModel.forward to correctly extract num_train_datapoints.