### PR TITLE
standardise experiment artifact organization

### DIFF
--- a/pretrain_classification.py
+++ b/pretrain_classification.py
@@ -29,7 +29,7 @@ parser.add_argument("--steps", type=int, default=100, help="number of steps that
 parser.add_argument("--epochs", type=int, default=10000, help="number of epochs to train for")
 parser.add_argument("--loadcheckpoint", type=str, default=None, help="checkpoint from which to continue training")
 parser.add_argument("--multigpu", action="store_true", help="enable multi-GPU training using data parallelism")
-parser.add_argument("--experiments-dir", type=str, default='workdir/experiments')
+parser.add_argument("--experiments-dir", type=str, default='workdir/experiments/classification')
 parser.add_argument("--name", type=str, default='test')
 
 args = parser.parse_args()

--- a/pretrain_classification.py
+++ b/pretrain_classification.py
@@ -1,6 +1,10 @@
 import argparse
+import os
+import uuid
 
 import torch
+
+from datetime import datetime
 from sklearn.metrics import accuracy_score, roc_auc_score
 from torch import nn
 
@@ -13,7 +17,7 @@ from tfmplayground.train import train
 from tfmplayground.utils import get_default_device, set_randomness_seed
 
 parser = argparse.ArgumentParser()
-parser.add_argument("--priordump", type=str, default="50x3_3_100k_classification.h5", help="path to the prior dump")
+parser.add_argument("--priordump", type=str, default="workdir/dumps/50x3_3_100k_classification.h5", help="path to the prior dump")
 parser.add_argument("--heads", type=int, default=6, help="number of attention heads")
 parser.add_argument("--embeddingsize", type=int, default=192, help="the size of the embeddings used for the cells")
 parser.add_argument("--hiddensize", type=int, default=768, help="size of the hidden layer of the mlps")
@@ -25,9 +29,19 @@ parser.add_argument("--steps", type=int, default=100, help="number of steps that
 parser.add_argument("--epochs", type=int, default=10000, help="number of epochs to train for")
 parser.add_argument("--loadcheckpoint", type=str, default=None, help="checkpoint from which to continue training")
 parser.add_argument("--multigpu", action="store_true", help="enable multi-GPU training using data parallelism")
-parser.add_argument("--runname", type=str, default="nanotabpfn", help="name of the training run, will be used to store the training checkpoints and for WandB logging")
+parser.add_argument("--experiments-dir", type=str, default='workdir/experiments')
+parser.add_argument("--name", type=str, default='test')
 
 args = parser.parse_args()
+
+ts = datetime.now().strftime("%y%m%d-%H%M%S")
+uid = uuid.uuid4().hex[:8]
+e_name = args.name.strip()
+e_id = f"{ts}-{uid}-{e_name}"
+e_root = os.path.join(args.experiments_dir, e_name)
+e_dir = os.path.join(e_root, e_id)
+os.makedirs(e_dir, exist_ok=True)
+print(f"experiment id: {e_id}")
 
 set_randomness_seed(2402)
 
@@ -99,5 +113,7 @@ trained_model, loss = train(
     callbacks=callbacks,
     ckpt=ckpt,
     multi_gpu=args.multigpu,
-    run_name=args.runname
+    run_name=e_name,
+    experiment_id=e_id,
+    experiment_dir=e_dir,
 )

--- a/pretrain_regression.py
+++ b/pretrain_regression.py
@@ -1,6 +1,10 @@
 import argparse
+import os
+import uuid
 
 import torch
+
+from datetime import datetime
 from pfns.bar_distribution import FullSupportBarDistribution
 from sklearn.metrics import r2_score
 
@@ -14,9 +18,9 @@ from tfmplayground.utils import get_default_device, set_randomness_seed, make_gl
 
 parser = argparse.ArgumentParser()
 
-parser.add_argument("--priordump", type=str, default="50x3_1280k_regression.h5", help="path to the prior dump")
-parser.add_argument("--saveweights", type=str, default="nanotabpfn_weights.pth", help="path to save the trained model to")
-parser.add_argument("--savebuckets", type=str, default="nanotabpfn_buckets.pth", help="path to save the bucket edges to")
+parser.add_argument("--priordump", type=str, default="workdir/dumps/50x3_1280k_regression.h5", help="path to the prior dump")
+parser.add_argument("--saveweights", type=str, default=None, help="path to save the trained model to")
+parser.add_argument("--savebuckets", type=str, default=None, help="path to save the bucket edges to")
 parser.add_argument("--heads", type=int, default=6, help="number of attention heads")
 parser.add_argument("--embeddingsize", type=int, default=192, help="the size of the embeddings used for the cells")
 parser.add_argument("--hiddensize", type=int, default=768, help="size of the hidden layer of the mlps")
@@ -28,8 +32,21 @@ parser.add_argument("--steps", type=int, default=100, help="number of steps that
 parser.add_argument("--epochs", type=int, default=10000, help="number of epochs to train for")
 parser.add_argument("--loadcheckpoint", type=str, default=None, help="checkpoint from which to continue training")
 parser.add_argument("--n_buckets", type=int, default=100, help="number of buckets for the data loader")
+parser.add_argument("--experiments-dir", type=str, default='workdir/experiments')
+parser.add_argument("--name", type=str, default='test')
 
 args = parser.parse_args()
+
+ts = datetime.now().strftime("%y%m%d-%H%M%S")
+uid = uuid.uuid4().hex[:8]
+e_name = args.name.strip()
+e_id = f"{ts}-{uid}-{e_name}"
+e_root = os.path.join(args.experiments_dir, e_name)
+e_dir = os.path.join(e_root, e_id)
+os.makedirs(e_dir, exist_ok=True)
+weights_path = os.path.join(e_dir, f"{e_id}-weights.pth") if not args.saveweights else args.saveweights
+buckets_path = os.path.join(e_dir, f"{e_id}-buckets.pth") if not args.savebuckets else args.savebuckets
+print(f"experiment id: {e_id}")
 
 set_randomness_seed(2402)
 
@@ -56,7 +73,7 @@ bucket_edges = make_global_bucket_edges(
 
 torch.save(
     bucket_edges,
-    args.savebuckets,
+    buckets_path,
 )
 
 if ckpt:
@@ -90,7 +107,9 @@ trained_model, loss = train(
     lr=args.lr,
     device=device,
     callbacks=callbacks,
-    ckpt=ckpt
+    ckpt=ckpt,
+    run_name=e_name,
+    experiment_id=e_id,
+    experiment_dir=e_dir,
+    weights_path=weights_path,
 )
-
-torch.save(trained_model.to('cpu').state_dict(), args.saveweights)

--- a/pretrain_regression.py
+++ b/pretrain_regression.py
@@ -42,7 +42,7 @@ e_id = f"{ts}-{uid}-{e_name}"
 e_root = os.path.join(args.experiments_dir, e_name)
 e_dir = os.path.join(e_root, e_id)
 os.makedirs(e_dir, exist_ok=True)
-buckets_path = os.path.join(e_dir, f"{e_id}-buckets.pth")
+buckets_path = os.path.join(e_dir, f"{e_id}-regressor-buckets.pth")
 print(f"experiment id: {e_id}")
 
 set_randomness_seed(2402)

--- a/pretrain_regression.py
+++ b/pretrain_regression.py
@@ -32,7 +32,7 @@ parser.add_argument("--steps", type=int, default=100, help="number of steps that
 parser.add_argument("--epochs", type=int, default=10000, help="number of epochs to train for")
 parser.add_argument("--loadcheckpoint", type=str, default=None, help="checkpoint from which to continue training")
 parser.add_argument("--n_buckets", type=int, default=100, help="number of buckets for the data loader")
-parser.add_argument("--experiments-dir", type=str, default='workdir/experiments')
+parser.add_argument("--experiments-dir", type=str, default='workdir/experiments/regression')
 parser.add_argument("--name", type=str, default='test')
 
 args = parser.parse_args()

--- a/pretrain_regression.py
+++ b/pretrain_regression.py
@@ -19,8 +19,6 @@ from tfmplayground.utils import get_default_device, set_randomness_seed, make_gl
 parser = argparse.ArgumentParser()
 
 parser.add_argument("--priordump", type=str, default="workdir/dumps/50x3_1280k_regression.h5", help="path to the prior dump")
-parser.add_argument("--saveweights", type=str, default=None, help="path to save the trained model to")
-parser.add_argument("--savebuckets", type=str, default=None, help="path to save the bucket edges to")
 parser.add_argument("--heads", type=int, default=6, help="number of attention heads")
 parser.add_argument("--embeddingsize", type=int, default=192, help="the size of the embeddings used for the cells")
 parser.add_argument("--hiddensize", type=int, default=768, help="size of the hidden layer of the mlps")
@@ -44,8 +42,7 @@ e_id = f"{ts}-{uid}-{e_name}"
 e_root = os.path.join(args.experiments_dir, e_name)
 e_dir = os.path.join(e_root, e_id)
 os.makedirs(e_dir, exist_ok=True)
-weights_path = os.path.join(e_dir, f"{e_id}-weights.pth") if not args.saveweights else args.saveweights
-buckets_path = os.path.join(e_dir, f"{e_id}-buckets.pth") if not args.savebuckets else args.savebuckets
+buckets_path = os.path.join(e_dir, f"{e_id}-buckets.pth")
 print(f"experiment id: {e_id}")
 
 set_randomness_seed(2402)
@@ -111,5 +108,4 @@ trained_model, loss = train(
     run_name=e_name,
     experiment_id=e_id,
     experiment_dir=e_dir,
-    weights_path=weights_path,
 )

--- a/tfmplayground/train.py
+++ b/tfmplayground/train.py
@@ -12,10 +12,22 @@ from tfmplayground.model import NanoTabPFNModel
 from tfmplayground.utils import get_default_device
 
 
-def train(model: NanoTabPFNModel, prior: DataLoader, criterion: nn.CrossEntropyLoss | FullSupportBarDistribution,
-          epochs: int, accumulate_gradients: int = 1, lr: float = 1e-4, device: torch.device = None,
-          callbacks: list[Callback] = None, ckpt: Dict[str, torch.Tensor] = None, multi_gpu: bool = False,
-          run_name: str = 'nanoTFM'):
+def train(
+    model: NanoTabPFNModel, 
+    prior: DataLoader, 
+    criterion: nn.CrossEntropyLoss | FullSupportBarDistribution,
+    epochs: int,
+    accumulate_gradients: int = 1,
+    lr: float = 1e-4,
+    device: torch.device = None,
+    callbacks: list[Callback] = None,
+    ckpt: Dict[str, torch.Tensor] = None,
+    multi_gpu: bool = False,
+    run_name: str = 'nanoTFM',
+    experiment_id: str = None,
+    experiment_dir: str = None,
+    weights_path: str = None,
+):
     """
     Trains our model on the given prior using the given criterion.
 
@@ -34,8 +46,6 @@ def train(model: NanoTabPFNModel, prior: DataLoader, criterion: nn.CrossEntropyL
     Returns:
         (torch.Tensor) a tensor of shape (num_rows, batch_size, num_features, embedding_size)
     """
-    work_dir = 'workdir/'+run_name
-    os.makedirs(work_dir, exist_ok=True)
     if multi_gpu:
         model = nn.DataParallel(model)
     if callbacks is None:
@@ -106,7 +116,9 @@ def train(model: NanoTabPFNModel, prior: DataLoader, criterion: nn.CrossEntropyL
                 'model': (model.module if multi_gpu else model).state_dict(),
                 'optimizer': optimizer.state_dict()
             }
-            torch.save(training_state, work_dir+'/latest_checkpoint.pth')
+            torch.save(training_state, os.path.join(experiment_dir, f'{experiment_id}-checkpoint.pth'))
+            if epoch == epochs:
+                torch.save(training_state, weights_path)
 
             for callback in callbacks:
                 if type(criterion) is FullSupportBarDistribution:

--- a/tfmplayground/train.py
+++ b/tfmplayground/train.py
@@ -115,7 +115,8 @@ def train(
                 'model': (model.module if multi_gpu else model).state_dict(),
                 'optimizer': optimizer.state_dict()
             }
-            torch.save(training_state, os.path.join(experiment_dir, f'{experiment_id}-checkpoint.pth'))
+            task_name = 'classifier' if classification_task else 'regressor'
+            torch.save(training_state, os.path.join(experiment_dir, f'{experiment_id}-{task_name}-checkpoint.pth'))
 
             for callback in callbacks:
                 if type(criterion) is FullSupportBarDistribution:

--- a/tfmplayground/train.py
+++ b/tfmplayground/train.py
@@ -26,7 +26,6 @@ def train(
     run_name: str = 'nanoTFM',
     experiment_id: str = None,
     experiment_dir: str = None,
-    weights_path: str = None,
 ):
     """
     Trains our model on the given prior using the given criterion.
@@ -117,8 +116,6 @@ def train(
                 'optimizer': optimizer.state_dict()
             }
             torch.save(training_state, os.path.join(experiment_dir, f'{experiment_id}-checkpoint.pth'))
-            if epoch == epochs:
-                torch.save(training_state, weights_path)
 
             for callback in callbacks:
                 if type(criterion) is FullSupportBarDistribution:


### PR DESCRIPTION
for better tracking and finding of the artifacts produced by the training script.

example:

```
.
├── pretrain_regression.py
└── workdir
    ├── dumps
    │   ├── 50x3_1280k_regression.h5
    │   ├── dump-d1000000b1r1000c100-regression-tabpfn-mlp.h5
    │   └── dump-d1000000b1r1000c100-regression-ticl-mlp.h5
    ├── experiments
    │   ├── cluster
    │   │   ├── 260330-151709-62835812-cluster
    │   │   │   ├── 260330-151709-62835812-cluster-buckets.pth
    │   │   │   └── 260330-151709-62835812-cluster-checkpoint.pth
    │   │   └── 260330-151913-c82d9c8c-cluster
    │   │       ├── 260330-151913-c82d9c8c-cluster-buckets.pth
    │   │       ├── 260330-151913-c82d9c8c-cluster-checkpoint.pth
    │   │       └── 260330-151913-c82d9c8c-cluster-weights.pth
    │   ├── test
    │   │   └── 260330-151706-ee91c1fe-test
    │   │       ├── 260330-151706-ee91c1fe-test-buckets.pth
    │   │       └── 260330-151706-ee91c1fe-test-checkpoint.pth
    │   └── xyz
    │       ├── 260330-151818-6394e7bc-xyz
    │       │   ├── 260330-151818-6394e7bc-xyz-buckets.pth
    │       │   ├── 260330-151818-6394e7bc-xyz-checkpoint.pth
    │       │   └── 260330-151818-6394e7bc-xyz-weights.pth
    │       └── 260330-151847-c140fc7c-xyz
    │           ├── 260330-151847-c140fc7c-xyz-buckets.pth
    │           ├── 260330-151847-c140fc7c-xyz-checkpoint.pth
    │           └── 260330-151847-c140fc7c-xyz-weights.pth
```

