### PR TITLE
cleanup codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This should take less than 5 min on a modern NVIDIA GPU (around 10 minutes on Ma
 
 We also offer a pre-generated dataset containing 1.28M tables with 50 datapoints and 3 features each for regression [here](https://ml.informatik.uni-freiburg.de/research-artifacts/pfefferle/TFM-Playground/50x3_1280k_regression.h5).
 
-You can pretrain on it using `python pretrain_regressor.py`.
+You can pretrain on it using `python pretrain_regression.py`.
 
 #### Step by Step Explanation (Classifier)
 

--- a/pretrain_classification.py
+++ b/pretrain_classification.py
@@ -87,7 +87,7 @@ class ToyEvaluationLoggerCallback(ConsoleLoggerCallback):
 
 
 class ProductionEvaluationLoggerCallback(WandbLoggerCallback):
-    def __init__(self, project, name = None, config = None, log_dir = None):
+    def __init__(self, project, name=None, config=None, log_dir=None):
         super().__init__(project, name, config, log_dir)
 
     def on_epoch_end(self, epoch, epoch_time, loss, model, **kwargs):

--- a/pretrain_classification.py
+++ b/pretrain_classification.py
@@ -108,7 +108,6 @@ class ProductionEvaluationLoggerCallback(WandbLoggerCallback):
         )
 
 
-# callbacks = [ProductionEvaluationLoggerCallback('nanoTFM', args.runname)]
 callbacks = [ToyEvaluationLoggerCallback(TOY_TASKS_CLASSIFICATION)]
 
 trained_model, loss = train(

--- a/pretrain_classification.py
+++ b/pretrain_classification.py
@@ -73,7 +73,7 @@ class ToyEvaluationLoggerCallback(ConsoleLoggerCallback):
     def __init__(self, tasks):
         self.tasks = tasks
 
-    def on_epoch_end(self, epoch: int, epoch_time: float, loss: float, model, **kwargs):
+    def on_epoch_end(self, epoch, epoch_time, loss, model, **kwargs):
         classifier = NanoTabPFNClassifier(model, device)
         predictions = get_openml_predictions(model=classifier, tasks=self.tasks)
         scores = []
@@ -87,10 +87,10 @@ class ToyEvaluationLoggerCallback(ConsoleLoggerCallback):
 
 
 class ProductionEvaluationLoggerCallback(WandbLoggerCallback):
-    def __init__(self, project: str, name: str = None, config: dict = None, log_dir: str = None):
+    def __init__(self, project, name = None, config = None, log_dir = None):
         super().__init__(project, name, config, log_dir)
 
-    def on_epoch_end(self, epoch: int, epoch_time: float, loss: float, model, **kwargs):
+    def on_epoch_end(self, epoch, epoch_time, loss, model, **kwargs):
         classifier = NanoTabPFNClassifier(model, device)
         predictions = get_openml_predictions(model=classifier, classification=True, tasks=TABARENA_TASKS)
         scores = []

--- a/pretrain_regression.py
+++ b/pretrain_regression.py
@@ -85,7 +85,7 @@ class EvaluationLoggerCallback(ConsoleLoggerCallback):
     def __init__(self, tasks):
         self.tasks = tasks
 
-    def on_epoch_end(self, epoch: int, epoch_time: float, loss: float, model, **kwargs):
+    def on_epoch_end(self, epoch, epoch_time, loss, model, **kwargs):
         regressor = NanoTabPFNRegressor(model, dist, device)
         predictions = get_openml_predictions(model=regressor, tasks=self.tasks)
         scores = []

--- a/tfmplayground/callbacks.py
+++ b/tfmplayground/callbacks.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 class Callback(ABC):
 
     @abstractmethod
-    def on_epoch_end(self, epoch: int, epoch_time: float, loss: float, model, **kwargs):
+    def on_epoch_end(self, epoch, epoch_time, loss, model, **kwargs):
         pass
 
     @abstractmethod
@@ -19,7 +19,7 @@ class BaseLoggerCallback(Callback):
 
 class ConsoleLoggerCallback(BaseLoggerCallback):
 
-    def on_epoch_end(self, epoch: int, epoch_time: float, loss: float, model, **kwargs):
+    def on_epoch_end(self, epoch, epoch_time, loss, model, **kwargs):
         print(f"Epoch {epoch:5d} | Time {epoch_time:5.2f}s | Mean Loss {loss:5.2f}", flush=True)
 
     def close(self):
@@ -28,12 +28,12 @@ class ConsoleLoggerCallback(BaseLoggerCallback):
 
 class TensorboardLoggerCallback(BaseLoggerCallback):
 
-    def __init__(self, log_dir: str):
+    def __init__(self, log_dir):
         from torch.utils.tensorboard import SummaryWriter
 
         self.writer = SummaryWriter(log_dir=log_dir)
 
-    def on_epoch_end(self, epoch: int, epoch_time: float, loss: float, model, **kwargs):
+    def on_epoch_end(self, epoch, epoch_time, loss, model, **kwargs):
         self.writer.add_scalar("Loss/train", loss, epoch)
         self.writer.add_scalar("Time/epoch", epoch_time, epoch)
 
@@ -43,7 +43,7 @@ class TensorboardLoggerCallback(BaseLoggerCallback):
 
 class WandbLoggerCallback(BaseLoggerCallback):
 
-    def __init__(self, project: str, name: str = None, config: dict = None, log_dir: str = None):
+    def __init__(self, project, name = None, config = None, log_dir = None):
         try:
             import wandb
 
@@ -52,7 +52,7 @@ class WandbLoggerCallback(BaseLoggerCallback):
         except ImportError as e:
             raise ImportError("wandb is not installed. Install it with: pip install wandb") from e
 
-    def on_epoch_end(self, epoch: int, epoch_time: float, loss: float, model, **kwargs):
+    def on_epoch_end(self, epoch, epoch_time, loss, model, **kwargs):
         log_dict = {"epoch": epoch, "loss": loss, " epoch_time": epoch_time}
         self.wandb.log(log_dict)
 

--- a/tfmplayground/callbacks.py
+++ b/tfmplayground/callbacks.py
@@ -2,7 +2,6 @@ from abc import ABC, abstractmethod
 
 
 class Callback(ABC):
-
     @abstractmethod
     def on_epoch_end(self, epoch, epoch_time, loss, model, **kwargs):
         pass
@@ -13,12 +12,10 @@ class Callback(ABC):
 
 
 class BaseLoggerCallback(Callback):
-
     pass
 
 
 class ConsoleLoggerCallback(BaseLoggerCallback):
-
     def on_epoch_end(self, epoch, epoch_time, loss, model, **kwargs):
         print(f"Epoch {epoch:5d} | Time {epoch_time:5.2f}s | Mean Loss {loss:5.2f}", flush=True)
 
@@ -27,7 +24,6 @@ class ConsoleLoggerCallback(BaseLoggerCallback):
 
 
 class TensorboardLoggerCallback(BaseLoggerCallback):
-
     def __init__(self, log_dir):
         from torch.utils.tensorboard import SummaryWriter
 
@@ -42,8 +38,7 @@ class TensorboardLoggerCallback(BaseLoggerCallback):
 
 
 class WandbLoggerCallback(BaseLoggerCallback):
-
-    def __init__(self, project, name = None, config = None, log_dir = None):
+    def __init__(self, project, name=None, config=None, log_dir=None):
         try:
             import wandb
 

--- a/tfmplayground/callbacks.py
+++ b/tfmplayground/callbacks.py
@@ -48,7 +48,7 @@ class WandbLoggerCallback(BaseLoggerCallback):
             raise ImportError("wandb is not installed. Install it with: pip install wandb") from e
 
     def on_epoch_end(self, epoch, epoch_time, loss, model, **kwargs):
-        log_dict = {"epoch": epoch, "loss": loss, " epoch_time": epoch_time}
+        log_dict = {"epoch": epoch, "loss": loss, "epoch_time": epoch_time}
         self.wandb.log(log_dict)
 
     def close(self):

--- a/tfmplayground/callbacks.py
+++ b/tfmplayground/callbacks.py
@@ -2,49 +2,31 @@ from abc import ABC, abstractmethod
 
 
 class Callback(ABC):
-    """Abstract base class for callbacks."""
 
     @abstractmethod
     def on_epoch_end(self, epoch: int, epoch_time: float, loss: float, model, **kwargs):
-        """
-        Called at the end of each epoch.
-
-        Args:
-            epoch (int): The current epoch number.
-            epoch_time (float): Time of the epoch in seconds.
-            loss (float): Mean loss for the epoch.
-            model: The model being trained.
-            **kwargs: Additional arguments.
-        """
         pass
 
     @abstractmethod
     def close(self):
-        """
-        Called to release any resources or perform cleanup.
-        """
         pass
 
 
 class BaseLoggerCallback(Callback):
-    """Abstract base class for logger callbacks."""
 
     pass
 
 
 class ConsoleLoggerCallback(BaseLoggerCallback):
-    """Logger callback that prints epoch information to the console."""
 
     def on_epoch_end(self, epoch: int, epoch_time: float, loss: float, model, **kwargs):
         print(f"Epoch {epoch:5d} | Time {epoch_time:5.2f}s | Mean Loss {loss:5.2f}", flush=True)
 
     def close(self):
-        """Nothing to clean up for print logger."""
         pass
 
 
 class TensorboardLoggerCallback(BaseLoggerCallback):
-    """Logger callback that logs epoch information to TensorBoard."""
 
     def __init__(self, log_dir: str):
         from torch.utils.tensorboard import SummaryWriter
@@ -60,18 +42,8 @@ class TensorboardLoggerCallback(BaseLoggerCallback):
 
 
 class WandbLoggerCallback(BaseLoggerCallback):
-    """Logger callback that logs epoch information to Weights & Biases."""
 
     def __init__(self, project: str, name: str = None, config: dict = None, log_dir: str = None):
-        """
-        Initializes a WandbLoggerCallback.
-
-        Args:
-            project (str): The name of the wandb project.
-            name (str, optional): The name of the run. Defaults to None.
-            config (dict, optional): Configuration dictionary for the run. Defaults to None.
-            log_dir (str, optional): Directory to save wandb logs. Defaults to None.
-        """
         try:
             import wandb
 

--- a/tfmplayground/callbacks.py
+++ b/tfmplayground/callbacks.py
@@ -75,7 +75,7 @@ class WandbLoggerCallback(BaseLoggerCallback):
         try:
             import wandb
 
-            self.wandb = wandb  # store wandb module to avoid import if not used
+            self.wandb = wandb
             wandb.init(project=project, name=name, id=name, config=config, dir=log_dir, resume="allow")
         except ImportError as e:
             raise ImportError("wandb is not installed. Install it with: pip install wandb") from e

--- a/tfmplayground/evaluation.py
+++ b/tfmplayground/evaluation.py
@@ -85,29 +85,6 @@ def get_openml_predictions(
     classification: bool | None = None,
     cache_directory: str | None = None,
 ):
-    """
-    Evaluates a model on a set of OpenML tasks and returns predictions.
-
-    Retrieves datasets from OpenML, applies preprocessing, and evaluates the given model on each task.
-    Returns true targets, predicted labels, and predicted probabilities for each dataset.
-
-    Args:
-        model (NanoTabPFNRegressor | NanoTabPFNClassifier):
-            A scikit-learn compatible model or classifier to be evaluated.
-        tasks (list[int] | str, optional):
-            A list of OpenML task IDs or the name of a benchmark suite.
-        max_n_features (int, optional):
-            Maximum number of features allowed for a task. Tasks exceeding this limit are skipped.
-        max_n_samples (int, optional):
-            Maximum number of instances allowed for a task. Tasks exceeding this limit are skipped.
-        classification (bool | None, optional):
-            Whether the model is a classifier (True) or regressor (False). If None, it is inferred from the model type.
-        cache_directory (str | None, optional):
-            Directory to save OpenML data. If None, default cache path is used.
-    Returns:
-        dict: A dictionary where keys are dataset names and values are tuples of
-            (true targets, predicted labels, predicted probabilities).
-    """
     if classification is None:
         classification = isinstance(model, NanoTabPFNClassifier)
 

--- a/tfmplayground/evaluation.py
+++ b/tfmplayground/evaluation.py
@@ -78,12 +78,12 @@ TABARENA_TASKS = [
 @torch.no_grad()
 def get_openml_predictions(
     *,
-    model: NanoTabPFNRegressor | NanoTabPFNClassifier,
-    tasks: list[int] | str = "tabarena-v0.1",
-    max_n_features: int = 500,
-    max_n_samples: int = 10_000,
-    classification: bool | None = None,
-    cache_directory: str | None = None,
+    model,
+    tasks = "tabarena-v0.1",
+    max_n_features = 500,
+    max_n_samples = 10_000,
+    classification = None,
+    cache_directory = None,
 ):
     if classification is None:
         classification = isinstance(model, NanoTabPFNClassifier)

--- a/tfmplayground/evaluation.py
+++ b/tfmplayground/evaluation.py
@@ -79,11 +79,11 @@ TABARENA_TASKS = [
 def get_openml_predictions(
     *,
     model,
-    tasks = "tabarena-v0.1",
-    max_n_features = 500,
-    max_n_samples = 10_000,
-    classification = None,
-    cache_directory = None,
+    tasks="tabarena-v0.1",
+    max_n_features=500,
+    max_n_samples=10_000,
+    classification=None,
+    cache_directory=None,
 ):
     if classification is None:
         classification = isinstance(model, NanoTabPFNClassifier)

--- a/tfmplayground/evaluation.py
+++ b/tfmplayground/evaluation.py
@@ -11,17 +11,15 @@ from sklearn.preprocessing import LabelEncoder
 from tfmplayground.interface import NanoTabPFNClassifier, NanoTabPFNRegressor
 
 TOY_TASKS_REGRESSION = [
-    362443,  # diabetes
+    362443,
 ]
 
 TOY_TASKS_CLASSIFICATION = [
-    59,  # iris
-    2382,  # wine
-    9946,  # breast_cancer
+    59,
+    2382,
+    9946,
 ]
 
-# we hardcode the list here because even if the tasks are cached
-# openml.study.get_suite("tabarena-v0.1") might fail if there are connection issues
 TABARENA_TASKS = [
     363612,
     363613,
@@ -111,7 +109,7 @@ def get_openml_predictions(
             (true targets, predicted labels, predicted probabilities).
     """
     if classification is None:
-        classification = isinstance(model, NanoTabPFNClassifier)  # TODO: change this once we support different models
+        classification = isinstance(model, NanoTabPFNClassifier)
 
     if cache_directory is not None:
         set_root_cache_directory(cache_directory)
@@ -128,22 +126,22 @@ def get_openml_predictions(
         task = openml.tasks.get_task(task_id, download_splits=False)
 
         if classification and task.task_type_id != TaskType.SUPERVISED_CLASSIFICATION:
-            continue  # skip task, only classification
+            continue
         if not classification and task.task_type_id != TaskType.SUPERVISED_REGRESSION:
-            continue  # skip task, only regression
+            continue
 
         dataset = task.get_dataset(download_data=False)
 
         n_features = dataset.qualities["NumberOfFeatures"]
         n_samples = dataset.qualities["NumberOfInstances"]
         if n_features > max_n_features or n_samples > max_n_samples:
-            continue  # skip task, too big
+            continue
 
         _, folds, _ = task.get_split_dimensions()
         tabarena_light = True
         if tabarena_light:
-            folds = 1  # code supports multiple folds but tabarena_light only has one
-        repeat = 0  # code only supports one repeat
+            folds = 1
+        repeat = 0
         targets = []
         predictions = []
         probabilities = []
@@ -168,7 +166,7 @@ def get_openml_predictions(
             predictions.append(y_pred)
             if classification:
                 y_proba = model.predict_proba(X_test)
-                if y_proba.shape[1] == 2:  # binary classification
+                if y_proba.shape[1] == 2:
                     y_proba = y_proba[:, 1]
                 probabilities.append(y_proba)
 

--- a/tfmplayground/evaluation.py
+++ b/tfmplayground/evaluation.py
@@ -200,18 +200,12 @@ if __name__ == "__main__":
         default=10_000,
         help="Maximum number of instances allowed for a task. Tasks exceeding this limit are skipped.",
     )
-    parser.add_argument(
-        "-num_mem_chunks",
-        type=int,
-        default=8,
-        help="Chunks attention computation into `num_mem_chunks` many chunks to reduce memory usage.",
-    )
     args = parser.parse_args()
 
     if args.model_type == "classification":
-        model = NanoTabPFNClassifier(model=args.checkpoint, num_mem_chunks=args.num_mem_chunks)
+        model = NanoTabPFNClassifier(model=args.checkpoint)
     else:
-        model = NanoTabPFNRegressor(model=args.checkpoint, dist=args.dist_path, num_mem_chunks=args.num_mem_chunks)
+        model = NanoTabPFNRegressor(model=args.checkpoint, dist=args.dist_path)
     model.model.eval()
 
     if args.tasks == "toy_tasks" and args.model_type == "regression":

--- a/tfmplayground/external_priors/__init__.py
+++ b/tfmplayground/external_priors/__init__.py
@@ -1,4 +1,3 @@
-
 from .base import PriorDataLoader, PriorDumpDataLoader
 from .tabicl import TabICLPriorDataLoader
 from .tabpfn import TabPFNPriorDataLoader, build_tabpfn_prior

--- a/tfmplayground/external_priors/__init__.py
+++ b/tfmplayground/external_priors/__init__.py
@@ -1,4 +1,3 @@
-"""Interfaces to external prior libraries (TabICL, TICL, TabPFN v1)."""
 
 from .base import PriorDataLoader, PriorDumpDataLoader
 from .tabicl import TabICLPriorDataLoader

--- a/tfmplayground/external_priors/__main__.py
+++ b/tfmplayground/external_priors/__main__.py
@@ -1,4 +1,3 @@
-
 from .main import main
 
 if __name__ == "__main__":

--- a/tfmplayground/external_priors/__main__.py
+++ b/tfmplayground/external_priors/__main__.py
@@ -1,4 +1,3 @@
-"""Entry point for the priors package."""
 
 from .main import main
 

--- a/tfmplayground/external_priors/base.py
+++ b/tfmplayground/external_priors/base.py
@@ -1,4 +1,3 @@
-
 from collections.abc import Callable, Iterator
 
 import h5py
@@ -9,7 +8,6 @@ from tqdm import tqdm
 
 
 class PriorDataLoader(DataLoader):
-
     def __init__(
         self,
         get_batch_function,
@@ -37,7 +35,6 @@ class PriorDataLoader(DataLoader):
 
 
 class PriorDumpDataLoader(DataLoader):
-
     def __init__(self, filename, num_steps, batch_size, device, starting_index=0):
         self.filename = filename
         self.num_steps = num_steps
@@ -92,9 +89,7 @@ class PriorDumpDataLoader(DataLoader):
         return self.num_steps
 
 
-def dump_prior_to_h5(
-    prior, max_classes, batch_size, save_path, problem_type, max_seq_len, max_features
-):
+def dump_prior_to_h5(prior, max_classes, batch_size, save_path, problem_type, max_seq_len, max_features):
 
     with h5py.File(save_path, "w") as f:
         dump_X = f.create_dataset(

--- a/tfmplayground/external_priors/base.py
+++ b/tfmplayground/external_priors/base.py
@@ -103,7 +103,7 @@ class PriorDumpDataLoader(DataLoader):
                 yield dict(
                     x=x.to(self.device),
                     y=y.to(self.device),
-                    target_y=y.to(self.device),  # target_y is identical to y (for downstream compatibility)
+                    target_y=y.to(self.device),
                     train_test_split_index=train_test_split_index[0].item(),
                 )
 
@@ -149,7 +149,6 @@ def dump_prior_to_h5(
             if isinstance(train_test_split_index, torch.Tensor):
                 train_test_split_index = train_test_split_index.item()
 
-            # pad x and y to the maximum sequence length and number of features needed for tabicl
             x_padded = np.pad(
                 x, ((0, 0), (0, max_seq_len - x.shape[1]), (0, max_features - x.shape[2])), mode="constant"
             )

--- a/tfmplayground/external_priors/base.py
+++ b/tfmplayground/external_priors/base.py
@@ -1,4 +1,3 @@
-from collections.abc import Callable, Iterator
 
 import h5py
 import numpy as np

--- a/tfmplayground/external_priors/base.py
+++ b/tfmplayground/external_priors/base.py
@@ -12,12 +12,12 @@ class PriorDataLoader(DataLoader):
 
     def __init__(
         self,
-        get_batch_function: Callable[..., dict[str, torch.Tensor | int]],
-        num_steps: int,
-        batch_size: int,
-        num_datapoints_max: int,
-        num_features: int,
-        device: torch.device,
+        get_batch_function,
+        num_steps,
+        batch_size,
+        num_datapoints_max,
+        num_features,
+        device,
     ):
         self.get_batch_function = get_batch_function
         self.num_steps = num_steps
@@ -26,13 +26,13 @@ class PriorDataLoader(DataLoader):
         self.num_features = num_features
         self.device = device
 
-    def __iter__(self) -> Iterator[dict[str, torch.Tensor | int]]:
+    def __iter__(self):
         return iter(
             self.get_batch_function(self.batch_size, self.num_datapoints_max, self.num_features)
             for _ in range(self.num_steps)
         )
 
-    def __len__(self) -> int:
+    def __len__(self):
         return self.num_steps
 
 
@@ -93,7 +93,7 @@ class PriorDumpDataLoader(DataLoader):
 
 
 def dump_prior_to_h5(
-    prior, max_classes: int, batch_size: int, save_path: str, problem_type: str, max_seq_len: int, max_features: int
+    prior, max_classes, batch_size, save_path, problem_type, max_seq_len, max_features
 ):
 
     with h5py.File(save_path, "w") as f:

--- a/tfmplayground/external_priors/base.py
+++ b/tfmplayground/external_priors/base.py
@@ -1,4 +1,3 @@
-"""Data loading utilities for tabular priors."""
 
 from collections.abc import Callable, Iterator
 
@@ -10,16 +9,6 @@ from tqdm import tqdm
 
 
 class PriorDataLoader(DataLoader):
-    """Generic DataLoader for synthetic data generation using a get_batch function.
-
-    Args:
-        get_batch_function (Callable): A function returning batches of data.
-        num_steps (int): Number of batches per epoch.
-        batch_size (int): Number of functions per batch.
-        num_datapoints_max (int): Max sequence length per function.
-        num_features (int): Number of input features.
-        device (torch.device): Device to move tensors to.
-    """
 
     def __init__(
         self,
@@ -48,14 +37,6 @@ class PriorDataLoader(DataLoader):
 
 
 class PriorDumpDataLoader(DataLoader):
-    """DataLoader that loads synthetic prior data from an HDF5 dump.
-
-    Args:
-        filename (str): Path to the HDF5 file.
-        num_steps (int): Number of batches per epoch.
-        batch_size (int): Batch size.
-        device (torch.device): Device to load tensors onto.
-    """
 
     def __init__(self, filename, num_steps, batch_size, device, starting_index=0):
         self.filename = filename
@@ -114,7 +95,6 @@ class PriorDumpDataLoader(DataLoader):
 def dump_prior_to_h5(
     prior, max_classes: int, batch_size: int, save_path: str, problem_type: str, max_seq_len: int, max_features: int
 ):
-    """Dumps synthetic prior data into an HDF5 file for later training."""
 
     with h5py.File(save_path, "w") as f:
         dump_X = f.create_dataset(

--- a/tfmplayground/external_priors/main.py
+++ b/tfmplayground/external_priors/main.py
@@ -74,7 +74,6 @@ def main():
             f"{args.num_batches}x{args.batch_size}_{args.max_seq_len}x{args.max_features}.h5"
         )
 
-    # infer the problem_type from max_classes
     problem_type = "classification" if args.max_classes > 0 else "regression"
 
     if args.lib == "ticl":
@@ -98,7 +97,7 @@ def main():
             device=device,
             **tabpfn_config,
         )
-    else:  # tabicl
+    else:
         prior = TabICLPriorDataLoader(
             num_steps=args.num_batches,
             batch_size=args.batch_size,

--- a/tfmplayground/external_priors/main.py
+++ b/tfmplayground/external_priors/main.py
@@ -1,4 +1,3 @@
-
 import argparse
 import random
 

--- a/tfmplayground/external_priors/main.py
+++ b/tfmplayground/external_priors/main.py
@@ -1,4 +1,3 @@
-"""Main module for the priors package."""
 
 import argparse
 import random

--- a/tfmplayground/external_priors/tabicl.py
+++ b/tfmplayground/external_priors/tabicl.py
@@ -8,15 +8,15 @@ class TabICLPriorDataLoader(DataLoader):
 
     def __init__(
         self,
-        num_steps: int,
-        batch_size: int,
-        num_datapoints_min: int,
-        num_datapoints_max: int,
-        min_features: int,
-        max_features: int,
-        max_num_classes: int,
-        device: torch.device,
-        prior_type: str = "mix_scm",
+        num_steps,
+        batch_size,
+        num_datapoints_min,
+        num_datapoints_max,
+        min_features,
+        max_features,
+        max_num_classes,
+        device,
+        prior_type = "mix_scm",
     ):
         self.num_steps = num_steps
         self.batch_size = batch_size

--- a/tfmplayground/external_priors/tabicl.py
+++ b/tfmplayground/external_priors/tabicl.py
@@ -57,15 +57,15 @@ class TabICLPriorDataLoader(DataLoader):
         x, y, active_features, seqlen, train_size = d
         active_features = active_features[
             0
-        ].item()  # should be all the same since we use batch_size_per_gp=batch_size (not true in practice!)
+        ].item()
         x = x[:, :, :active_features]
         train_test_split_index = train_size[
             0
-        ].item()  # should be all the same since we use batch_size_per_gp=batch_size
+        ].item()
         return dict(
             x=x.to(self.device),
             y=y.to(self.device),
-            target_y=y.to(self.device),  # target_y is identical to y (for downstream compatibility)
+            target_y=y.to(self.device),
             train_test_split_index=train_test_split_index,
         )
 

--- a/tfmplayground/external_priors/tabicl.py
+++ b/tfmplayground/external_priors/tabicl.py
@@ -1,11 +1,9 @@
-
 import torch
 from tabicl.prior.dataset import PriorDataset as TabICLPriorDataset
 from torch.utils.data import DataLoader
 
 
 class TabICLPriorDataLoader(DataLoader):
-
     def __init__(
         self,
         num_steps,
@@ -16,7 +14,7 @@ class TabICLPriorDataLoader(DataLoader):
         max_features,
         max_num_classes,
         device,
-        prior_type = "mix_scm",
+        prior_type="mix_scm",
     ):
         self.num_steps = num_steps
         self.batch_size = batch_size
@@ -41,13 +39,9 @@ class TabICLPriorDataLoader(DataLoader):
 
     def tabicl_to_ours(self, d):
         x, y, active_features, seqlen, train_size = d
-        active_features = active_features[
-            0
-        ].item()
+        active_features = active_features[0].item()
         x = x[:, :, :active_features]
-        train_test_split_index = train_size[
-            0
-        ].item()
+        train_test_split_index = train_size[0].item()
         return dict(
             x=x.to(self.device),
             y=y.to(self.device),

--- a/tfmplayground/external_priors/tabicl.py
+++ b/tfmplayground/external_priors/tabicl.py
@@ -1,4 +1,3 @@
-import torch
 from tabicl.prior.dataset import PriorDataset as TabICLPriorDataset
 from torch.utils.data import DataLoader
 

--- a/tfmplayground/external_priors/tabicl.py
+++ b/tfmplayground/external_priors/tabicl.py
@@ -1,4 +1,3 @@
-"""DataLoader and configuration for TabICL-based priors."""
 
 import torch
 from tabicl.prior.dataset import PriorDataset as TabICLPriorDataset
@@ -6,19 +5,6 @@ from torch.utils.data import DataLoader
 
 
 class TabICLPriorDataLoader(DataLoader):
-    """DataLoader sampling synthetic prior data on-the-fly from TabICL's PriorDataset.
-
-    Args:
-        num_steps (int): Number of batches to generate per epoch.
-        batch_size (int): Number of functions per batch.
-        num_datapoints_min (int): Minimum number of datapoints per function.
-        num_datapoints_max (int): Maximum number of datapoints per function.
-        min_features (int): Minimum number of features in x.
-        max_features (int): Maximum number of features in x.
-        max_num_classes (int): Maximum number of classes (for classification tasks).
-        prior_type (str): Type of prior: 'mlp_scm', 'tree_scm', 'mix_scm' (default), or 'dummy'.
-        device (torch.device): Target device for tensors.
-    """
 
     def __init__(
         self,

--- a/tfmplayground/external_priors/tabpfn.py
+++ b/tfmplayground/external_priors/tabpfn.py
@@ -1,17 +1,9 @@
-"""DataLoader and configuration for TabPFN v1-based priors."""
 
 import torch
 from tabpfn_prior import TabPFNPriorDataLoader  # noqa: F401
 
 
 def _get_tabpfn_prior_config(prior_type: str) -> dict:
-    """Return the default kwargs for TabPFN priors.
-
-    Args:
-        prior_type: Type of TabPFN prior ('mlp', 'gp', 'prior_bag')
-    Note:
-        gp_mix is included in the library wrapper but lacks implementation so its not included here
-    """
 
     if prior_type == "mlp":
         return {
@@ -58,15 +50,6 @@ def _get_tabpfn_prior_config(prior_type: str) -> dict:
 
 
 def build_tabpfn_prior(prior_type: str, max_classes: int) -> dict:
-    """Builds TabPFN prior configuration with appropriate settings for regression or classification.
-
-    Args:
-        prior_type: Type of TabPFN prior ('mlp', 'gp', 'prior_bag')
-        max_classes: Maximum number of classes
-
-    Returns:
-        dict with 'flexible', 'max_num_classes', and 'prior_config' keys
-    """
     is_regression = max_classes == 0
 
     return {

--- a/tfmplayground/external_priors/tabpfn.py
+++ b/tfmplayground/external_priors/tabpfn.py
@@ -46,13 +46,12 @@ def _get_tabpfn_prior_config(prior_type: str) -> dict:
             "sampling": "uniform",
         }
     elif prior_type == "prior_bag":
-        # prior bag combines MLP and GP priors
         mlp_config = _get_tabpfn_prior_config("mlp")
         gp_config = _get_tabpfn_prior_config("gp")
         return {
             **mlp_config,
             **gp_config,
-            "prior_bag_exp_weights_1": 2.0,  # GP gets weight 1.0, MLP gets this value (default 2.0).
+            "prior_bag_exp_weights_1": 2.0,
         }
     else:
         raise ValueError(f"Unsupported TabPFN prior type: {prior_type}")
@@ -71,12 +70,10 @@ def build_tabpfn_prior(prior_type: str, max_classes: int) -> dict:
     is_regression = max_classes == 0
 
     return {
-        "flexible": not is_regression,  # false for regression, true for classification
+        "flexible": not is_regression,
         "max_num_classes": 2
         if is_regression
-        else max_classes,  # library weirdly requires >=2 regardless of regression or classification
-        # num_classes parameter in the library code is equated to max_num_classes
-        # so its not varied separately here
+        else max_classes,
         "prior_config": {
             **_get_tabpfn_prior_config(prior_type),
         },

--- a/tfmplayground/external_priors/tabpfn.py
+++ b/tfmplayground/external_priors/tabpfn.py
@@ -3,7 +3,7 @@ import torch
 from tabpfn_prior import TabPFNPriorDataLoader  # noqa: F401
 
 
-def _get_tabpfn_prior_config(prior_type: str) -> dict:
+def _get_tabpfn_prior_config(prior_type):
 
     if prior_type == "mlp":
         return {
@@ -49,7 +49,7 @@ def _get_tabpfn_prior_config(prior_type: str) -> dict:
         raise ValueError(f"Unsupported TabPFN prior type: {prior_type}")
 
 
-def build_tabpfn_prior(prior_type: str, max_classes: int) -> dict:
+def build_tabpfn_prior(prior_type, max_classes):
     is_regression = max_classes == 0
 
     return {

--- a/tfmplayground/external_priors/tabpfn.py
+++ b/tfmplayground/external_priors/tabpfn.py
@@ -1,4 +1,3 @@
-
 import torch
 from tabpfn_prior import TabPFNPriorDataLoader  # noqa: F401
 
@@ -54,9 +53,7 @@ def build_tabpfn_prior(prior_type, max_classes):
 
     return {
         "flexible": not is_regression,
-        "max_num_classes": 2
-        if is_regression
-        else max_classes,
+        "max_num_classes": 2 if is_regression else max_classes,
         "prior_config": {
             **_get_tabpfn_prior_config(prior_type),
         },

--- a/tfmplayground/external_priors/ticl.py
+++ b/tfmplayground/external_priors/ticl.py
@@ -1,4 +1,3 @@
-"""DataLoader and configuration for TICL-based priors."""
 
 import torch
 from ticl.dataloader import PriorDataLoader as TICLPriorDataset
@@ -7,11 +6,6 @@ from torch.utils.data import DataLoader
 
 
 def _get_ticl_prior_config(prior_type: str) -> dict:
-    """Return the default kwargs for MLPPrior, GPPrior, or classification priors.
-
-    Args:
-        prior_type: Type of TICL prior ('mlp', 'gp', 'classification_adapter', etc.)
-    """
 
     if prior_type == "mlp":
         return {
@@ -68,13 +62,6 @@ def _get_ticl_prior_config(prior_type: str) -> dict:
 def build_ticl_prior(
     prior_type: str, base_prior: str = None, max_num_classes: int = None
 ) -> MLPPrior | GPPrior | ClassificationAdapterPrior | BooleanConjunctionPrior | StepFunctionPrior:
-    """Builds a TICL prior based on the prior type string using the defaults in this module.
-
-    Args:
-        prior_type: Type of TICL prior ('mlp', 'gp', 'classification_adapter', etc.)
-        base_prior: Base regression prior for composite priors (e.g., 'mlp' or 'gp' for classification_adapter)
-        max_num_classes: Maximum number of classes for classification priors
-    """
 
     cfg = _get_ticl_prior_config(prior_type)
 
@@ -99,17 +86,6 @@ def build_ticl_prior(
 
 
 class TICLPriorDataLoader(DataLoader):
-    """DataLoader sampling synthetic prior data from TICL's PriorDataLoader.
-
-    Args:
-        prior (Any): A TICL prior object supporting get_batch.
-        num_steps (int): Number of batches per epoch.
-        batch_size (int): Number of functions sampled per batch.
-        num_datapoints_max (int): Number of datapoints sampled per function.
-        num_features (int): Dimensionality of x vectors.
-        device (torch.device): Target device for tensors.
-        min_eval_pos (int, optional): Minimum evaluation position in the sequence.
-    """
 
     def __init__(
         self,

--- a/tfmplayground/external_priors/ticl.py
+++ b/tfmplayground/external_priors/ticl.py
@@ -5,7 +5,7 @@ from ticl.priors import BooleanConjunctionPrior, ClassificationAdapterPrior, GPP
 from torch.utils.data import DataLoader
 
 
-def _get_ticl_prior_config(prior_type: str) -> dict:
+def _get_ticl_prior_config(prior_type):
 
     if prior_type == "mlp":
         return {
@@ -60,8 +60,8 @@ def _get_ticl_prior_config(prior_type: str) -> dict:
 
 
 def build_ticl_prior(
-    prior_type: str, base_prior: str = None, max_num_classes: int = None
-) -> MLPPrior | GPPrior | ClassificationAdapterPrior | BooleanConjunctionPrior | StepFunctionPrior:
+    prior_type, base_prior = None, max_num_classes = None
+):
 
     cfg = _get_ticl_prior_config(prior_type)
 
@@ -90,12 +90,12 @@ class TICLPriorDataLoader(DataLoader):
     def __init__(
         self,
         prior,
-        num_steps: int,
-        batch_size: int,
-        num_datapoints_max: int,
-        num_features: int,
-        min_eval_pos: int,
-        device: torch.device,
+        num_steps,
+        batch_size,
+        num_datapoints_max,
+        num_features,
+        min_eval_pos,
+        device,
     ):
         self.num_steps = num_steps
         self.device = device

--- a/tfmplayground/external_priors/ticl.py
+++ b/tfmplayground/external_priors/ticl.py
@@ -84,14 +84,9 @@ def build_ticl_prior(
         return GPPrior(cfg)
     elif prior_type == "classification_adapter":
         if base_prior is None:
-            base_prior = "mlp"  # default to MLP
-        # build the base regression prior
+            base_prior = "mlp"
         base_prior_obj = build_ticl_prior(base_prior)
 
-        # we equate them rather than treating num_classes as a separate parameter because:
-        # - max_num_classes serves as the upper bound for TICL's internal sampling
-        # - even with num_classes set to a constant, TICL's class_sampler_f() will internally
-        #   vary the actual number of classes (50% chance of 2, 50% chance of uniform(2, num_classes))
         cfg["max_num_classes"] = max_num_classes
         cfg["num_classes"] = max_num_classes
         return ClassificationAdapterPrior(base_prior_obj, **cfg)
@@ -148,7 +143,7 @@ class TICLPriorDataLoader(DataLoader):
         return dict(
             x=x.to(self.device),
             y=y.to(self.device),
-            target_y=target_y.to(self.device),  # target_y is identical to y (for downstream compatibility)
+            target_y=target_y.to(self.device),
             train_test_split_index=train_test_split_index,
         )
 

--- a/tfmplayground/external_priors/ticl.py
+++ b/tfmplayground/external_priors/ticl.py
@@ -1,4 +1,3 @@
-
 import torch
 from ticl.dataloader import PriorDataLoader as TICLPriorDataset
 from ticl.priors import BooleanConjunctionPrior, ClassificationAdapterPrior, GPPrior, MLPPrior, StepFunctionPrior
@@ -59,9 +58,7 @@ def _get_ticl_prior_config(prior_type):
         raise ValueError(f"Unsupported TICL prior type: {prior_type}")
 
 
-def build_ticl_prior(
-    prior_type, base_prior = None, max_num_classes = None
-):
+def build_ticl_prior(prior_type, base_prior=None, max_num_classes=None):
 
     cfg = _get_ticl_prior_config(prior_type)
 
@@ -86,7 +83,6 @@ def build_ticl_prior(
 
 
 class TICLPriorDataLoader(DataLoader):
-
     def __init__(
         self,
         prior,

--- a/tfmplayground/interface.py
+++ b/tfmplayground/interface.py
@@ -36,7 +36,7 @@ def to_numeric(x):
     return x.apply(pd.to_numeric, errors="coerce").to_numpy()
 
 
-def get_feature_preprocessor(X: np.ndarray | pd.DataFrame) -> ColumnTransformer:
+def get_feature_preprocessor(X):
     X = pd.DataFrame(X)
     num_mask = []
     cat_mask = []
@@ -83,9 +83,9 @@ class NanoTabPFNClassifier:
 
     def __init__(
         self,
-        model: NanoTabPFNModel | str | None = None,
-        device: None | str | torch.device = None,
-        num_mem_chunks: int = 8,
+        model = None,
+        device = None,
+        num_mem_chunks = 8,
     ):
         if device is None:
             device = get_default_device()
@@ -105,17 +105,17 @@ class NanoTabPFNClassifier:
         self.device = device
         self.num_mem_chunks = num_mem_chunks
 
-    def fit(self, X_train: np.ndarray, y_train: np.ndarray):
+    def fit(self, X_train, y_train):
         self.feature_preprocessor = get_feature_preprocessor(X_train)
         self.X_train = self.feature_preprocessor.fit_transform(X_train)
         self.y_train = y_train
         self.num_classes = max(set(y_train)) + 1
 
-    def predict(self, X_test: np.ndarray) -> np.ndarray:
+    def predict(self, X_test):
         predicted_probabilities = self.predict_proba(X_test)
         return predicted_probabilities.argmax(axis=1)
 
-    def predict_proba(self, X_test: np.ndarray) -> np.ndarray:
+    def predict_proba(self, X_test):
         x = np.concatenate((self.X_train, self.feature_preprocessor.transform(X_test)))
         y = self.y_train
         with torch.no_grad():
@@ -133,10 +133,10 @@ class NanoTabPFNRegressor:
 
     def __init__(
         self,
-        model: NanoTabPFNModel | str | None = None,
-        dist: FullSupportBarDistribution | str | None = None,
-        device: str | torch.device | None = None,
-        num_mem_chunks: int = 8,
+        model = None,
+        dist = None,
+        device = None,
+        num_mem_chunks = 8,
     ):
         if device is None:
             device = get_default_device()
@@ -170,7 +170,7 @@ class NanoTabPFNRegressor:
         self.dist = dist
         self.num_mem_chunks = num_mem_chunks
 
-    def fit(self, X_train: np.ndarray, y_train: np.ndarray):
+    def fit(self, X_train, y_train):
         self.feature_preprocessor = get_feature_preprocessor(X_train)
         self.X_train = self.feature_preprocessor.fit_transform(X_train)
         self.y_train = y_train
@@ -179,7 +179,7 @@ class NanoTabPFNRegressor:
         self.y_train_std = np.std(self.y_train, ddof=1) + 1e-8
         self.y_train_n = (self.y_train - self.y_train_mean) / self.y_train_std
 
-    def predict(self, X_test: np.ndarray) -> np.ndarray:
+    def predict(self, X_test):
         X = np.concatenate((self.X_train, self.feature_preprocessor.transform(X_test)))
         y = self.y_train_n
 

--- a/tfmplayground/interface.py
+++ b/tfmplayground/interface.py
@@ -16,9 +16,6 @@ from tfmplayground.utils import get_default_device
 
 
 def init_model_from_state_dict_file(file_path):
-    """
-    reads model architecture from state dict, instantiates the architecture and loads the weights
-    """
     state_dict = torch.load(file_path, map_location=torch.device("cpu"))
     model = NanoTabPFNModel(
         num_attention_heads=state_dict["architecture"]["num_attention_heads"],
@@ -40,9 +37,6 @@ def to_numeric(x):
 
 
 def get_feature_preprocessor(X: np.ndarray | pd.DataFrame) -> ColumnTransformer:
-    """
-    fits a preprocessor that imputes NaNs, encodes categorical features and removes constant features
-    """
     X = pd.DataFrame(X)
     num_mask = []
     cat_mask = []
@@ -86,7 +80,6 @@ def get_feature_preprocessor(X: np.ndarray | pd.DataFrame) -> ColumnTransformer:
 
 
 class NanoTabPFNClassifier:
-    """scikit-learn like interface"""
 
     def __init__(
         self,
@@ -113,22 +106,16 @@ class NanoTabPFNClassifier:
         self.num_mem_chunks = num_mem_chunks
 
     def fit(self, X_train: np.ndarray, y_train: np.ndarray):
-        """stores X_train and y_train for later use, also computes the highest class number occuring in num_classes"""
         self.feature_preprocessor = get_feature_preprocessor(X_train)
         self.X_train = self.feature_preprocessor.fit_transform(X_train)
         self.y_train = y_train
         self.num_classes = max(set(y_train)) + 1
 
     def predict(self, X_test: np.ndarray) -> np.ndarray:
-        """calls predit_proba and picks the class with the highest probability for each datapoint"""
         predicted_probabilities = self.predict_proba(X_test)
         return predicted_probabilities.argmax(axis=1)
 
     def predict_proba(self, X_test: np.ndarray) -> np.ndarray:
-        """
-        creates (x,y), runs it through our PyTorch Model, cuts off the classes that didn't appear in the training data
-        and applies softmax to get the probabilities
-        """
         x = np.concatenate((self.X_train, self.feature_preprocessor.transform(X_test)))
         y = self.y_train
         with torch.no_grad():
@@ -143,7 +130,6 @@ class NanoTabPFNClassifier:
 
 
 class NanoTabPFNRegressor:
-    """scikit-learn like interface"""
 
     def __init__(
         self,
@@ -185,10 +171,6 @@ class NanoTabPFNRegressor:
         self.num_mem_chunks = num_mem_chunks
 
     def fit(self, X_train: np.ndarray, y_train: np.ndarray):
-        """
-        Stores X_train and y_train for later use.
-        Computes target normalization.
-        """
         self.feature_preprocessor = get_feature_preprocessor(X_train)
         self.X_train = self.feature_preprocessor.fit_transform(X_train)
         self.y_train = y_train
@@ -198,11 +180,6 @@ class NanoTabPFNRegressor:
         self.y_train_n = (self.y_train - self.y_train_mean) / self.y_train_std
 
     def predict(self, X_test: np.ndarray) -> np.ndarray:
-        """
-        Performs in-context learning using X_train and y_train.
-        Predicts the means of the output distributions for X_test.
-        Renormalizes the predictions back to the original target scale.
-        """
         X = np.concatenate((self.X_train, self.feature_preprocessor.transform(X_test)))
         y = self.y_train_n
 

--- a/tfmplayground/interface.py
+++ b/tfmplayground/interface.py
@@ -31,8 +31,6 @@ def init_model_from_state_dict_file(file_path):
     return model
 
 
-# doing these as lambdas would cause NanoTabPFNClassifier to not be pickle-able,
-# which would cause issues if we want to run it inside the tabarena codebase
 def to_pandas(x):
     return pd.DataFrame(x) if not isinstance(x, pd.DataFrame) else x
 
@@ -57,22 +55,21 @@ def get_feature_preprocessor(X: np.ndarray | pd.DataFrame) -> ColumnTransformer:
         non_nan_entries = X[col].notna().sum()
         numeric_entries = (
             pd.to_numeric(X[col], errors="coerce").notna().sum()
-        )  # in case numeric columns are stored as strings
+        )
         num_mask.append(non_nan_entries == numeric_entries)
         cat_mask.append(non_nan_entries != numeric_entries)
-        # num_mask.append(is_numeric_dtype(X[col]))  # Assumes pandas dtype is correct
 
     num_mask = np.array(num_mask)
     cat_mask = np.array(cat_mask)
 
     num_transformer = Pipeline(
         [
-            ("to_pandas", FunctionTransformer(to_pandas)),  # to apply pd.to_numeric of pandas
-            ("to_numeric", FunctionTransformer(to_numeric)),  # in case numeric columns are stored as strings
+            ("to_pandas", FunctionTransformer(to_pandas)),
+            ("to_numeric", FunctionTransformer(to_numeric)),
             (
                 "imputer",
                 SimpleImputer(strategy="mean", add_indicator=True),
-            ),  # median might be better because of outliers
+            ),
         ]
     )
     cat_transformer = Pipeline(
@@ -135,14 +132,12 @@ class NanoTabPFNClassifier:
         x = np.concatenate((self.X_train, self.feature_preprocessor.transform(X_test)))
         y = self.y_train
         with torch.no_grad():
-            x = torch.from_numpy(x).unsqueeze(0).to(torch.float).to(self.device)  # introduce batch size 1
+            x = torch.from_numpy(x).unsqueeze(0).to(torch.float).to(self.device)
             y = torch.from_numpy(y).unsqueeze(0).to(torch.float).to(self.device)
             out = self.model(
                 (x, y), train_test_split_index=len(self.X_train), num_mem_chunks=self.num_mem_chunks
-            ).squeeze(0)  # remove batch size 1
-            # our pretrained classifier supports up to num_outputs classes, if the dataset has less we cut off the rest
+            ).squeeze(0)
             out = out[:, : self.num_classes]
-            # apply softmax to get a probability distribution
             probabilities = F.softmax(out, dim=1)
             return probabilities.to("cpu").numpy()
 

--- a/tfmplayground/interface.py
+++ b/tfmplayground/interface.py
@@ -47,9 +47,7 @@ def get_feature_preprocessor(X):
             cat_mask.append(False)
             continue
         non_nan_entries = X[col].notna().sum()
-        numeric_entries = (
-            pd.to_numeric(X[col], errors="coerce").notna().sum()
-        )
+        numeric_entries = pd.to_numeric(X[col], errors="coerce").notna().sum()
         num_mask.append(non_nan_entries == numeric_entries)
         cat_mask.append(non_nan_entries != numeric_entries)
 
@@ -80,12 +78,11 @@ def get_feature_preprocessor(X):
 
 
 class NanoTabPFNClassifier:
-
     def __init__(
         self,
-        model = None,
-        device = None,
-        num_mem_chunks = 8,
+        model=None,
+        device=None,
+        num_mem_chunks=8,
     ):
         if device is None:
             device = get_default_device()
@@ -130,13 +127,12 @@ class NanoTabPFNClassifier:
 
 
 class NanoTabPFNRegressor:
-
     def __init__(
         self,
-        model = None,
-        dist = None,
-        device = None,
-        num_mem_chunks = 8,
+        model=None,
+        dist=None,
+        device=None,
+        num_mem_chunks=8,
     ):
         if device is None:
             device = get_default_device()

--- a/tfmplayground/interface.py
+++ b/tfmplayground/interface.py
@@ -82,7 +82,6 @@ class NanoTabPFNClassifier:
         self,
         model=None,
         device=None,
-        num_mem_chunks=8,
     ):
         if device is None:
             device = get_default_device()
@@ -100,7 +99,6 @@ class NanoTabPFNClassifier:
             model = init_model_from_state_dict_file(model)
         self.model = model.to(device)
         self.device = device
-        self.num_mem_chunks = num_mem_chunks
 
     def fit(self, X_train, y_train):
         self.feature_preprocessor = get_feature_preprocessor(X_train)
@@ -118,9 +116,7 @@ class NanoTabPFNClassifier:
         with torch.no_grad():
             x = torch.from_numpy(x).unsqueeze(0).to(torch.float).to(self.device)
             y = torch.from_numpy(y).unsqueeze(0).to(torch.float).to(self.device)
-            out = self.model(
-                (x, y), train_test_split_index=len(self.X_train), num_mem_chunks=self.num_mem_chunks
-            ).squeeze(0)
+            out = self.model((x, y), train_test_split_index=len(self.X_train)).squeeze(0)
             out = out[:, : self.num_classes]
             probabilities = F.softmax(out, dim=1)
             return probabilities.to("cpu").numpy()
@@ -132,7 +128,6 @@ class NanoTabPFNRegressor:
         model=None,
         dist=None,
         device=None,
-        num_mem_chunks=8,
     ):
         if device is None:
             device = get_default_device()
@@ -164,7 +159,6 @@ class NanoTabPFNRegressor:
         self.model = model.to(device)
         self.device = device
         self.dist = dist
-        self.num_mem_chunks = num_mem_chunks
 
     def fit(self, X_train, y_train):
         self.feature_preprocessor = get_feature_preprocessor(X_train)
@@ -183,9 +177,7 @@ class NanoTabPFNRegressor:
             X_tensor = torch.tensor(X, dtype=torch.float32, device=self.device).unsqueeze(0)
             y_tensor = torch.tensor(y, dtype=torch.float32, device=self.device).unsqueeze(0)
 
-            logits = self.model(
-                (X_tensor, y_tensor), train_test_split_index=len(self.X_train), num_mem_chunks=self.num_mem_chunks
-            ).squeeze(0)
+            logits = self.model((X_tensor, y_tensor), train_test_split_index=len(self.X_train)).squeeze(0)
             preds_n = self.dist.mean(logits)
             preds = preds_n * self.y_train_std + self.y_train_mean
 

--- a/tfmplayground/models/nanotabpfn.py
+++ b/tfmplayground/models/nanotabpfn.py
@@ -9,9 +9,7 @@ from torch.nn.modules.transformer import LayerNorm, Linear, MultiheadAttention
 
 
 class NanoTabPFNModel(nn.Module):
-    def __init__(
-        self, embedding_size, num_attention_heads, mlp_hidden_size, num_layers, num_outputs
-    ):
+    def __init__(self, embedding_size, num_attention_heads, mlp_hidden_size, num_layers, num_outputs):
         super().__init__()
         self.embedding_size = embedding_size
         self.num_attention_heads = num_attention_heads
@@ -36,9 +34,7 @@ class NanoTabPFNModel(nn.Module):
         elif len(args) == 1 and isinstance(args[0], tuple):
             return self._forward(*args, **kwargs)
 
-    def _forward(
-        self, src, train_test_split_index, num_mem_chunks = 1
-    ):
+    def _forward(self, src, train_test_split_index, num_mem_chunks=1):
         x_src, y_src = src
         if len(y_src.shape) < len(x_src.shape):
             y_src = y_src.unsqueeze(-1)
@@ -81,14 +77,13 @@ class TargetEncoder(nn.Module):
 
 
 class TransformerEncoderLayer(nn.Module):
-
     def __init__(
         self,
         embedding_size,
         nhead,
         mlp_hidden_size,
-        layer_norm_eps = 1e-5,
-        batch_first = True,
+        layer_norm_eps=1e-5,
+        batch_first=True,
         device=None,
         dtype=None,
     ):
@@ -107,7 +102,7 @@ class TransformerEncoderLayer(nn.Module):
         self.norm2 = LayerNorm(embedding_size, eps=layer_norm_eps, device=device, dtype=dtype)
         self.norm3 = LayerNorm(embedding_size, eps=layer_norm_eps, device=device, dtype=dtype)
 
-    def forward(self, src, train_test_split_index, num_mem_chunks = 1):
+    def forward(self, src, train_test_split_index, num_mem_chunks=1):
         batch_size, rows_size, col_size, embedding_size = src.shape
         src = src.reshape(batch_size * rows_size, col_size, embedding_size)
 
@@ -166,9 +161,7 @@ def memory_chunking(num_mem_chunks):
                 return func(x)
             chunk_size = max(1, math.ceil(x.shape[0] / num_mem_chunks))
             for x_split in torch.split(x, split_size_or_sections=chunk_size, dim=0):
-                x_split[:] = func(
-                    x_split
-                )
+                x_split[:] = func(x_split)
             return x
 
         return wrapper

--- a/tfmplayground/models/nanotabpfn.py
+++ b/tfmplayground/models/nanotabpfn.py
@@ -10,7 +10,7 @@ from torch.nn.modules.transformer import LayerNorm, Linear, MultiheadAttention
 
 class NanoTabPFNModel(nn.Module):
     def __init__(
-        self, embedding_size: int, num_attention_heads: int, mlp_hidden_size: int, num_layers: int, num_outputs: int
+        self, embedding_size, num_attention_heads, mlp_hidden_size, num_layers, num_outputs
     ):
         super().__init__()
         self.embedding_size = embedding_size
@@ -27,7 +27,7 @@ class NanoTabPFNModel(nn.Module):
             )
         self.decoder = Decoder(embedding_size, mlp_hidden_size, num_outputs)
 
-    def forward(self, *args, **kwargs) -> torch.Tensor:
+    def forward(self, *args, **kwargs):
         if len(args) == 3:
             x = args[0]
             if args[2] is not None:
@@ -37,8 +37,8 @@ class NanoTabPFNModel(nn.Module):
             return self._forward(*args, **kwargs)
 
     def _forward(
-        self, src: tuple[torch.Tensor, torch.Tensor], train_test_split_index: int, num_mem_chunks: int = 1
-    ) -> torch.Tensor:
+        self, src, train_test_split_index, num_mem_chunks = 1
+    ):
         x_src, y_src = src
         if len(y_src.shape) < len(x_src.shape):
             y_src = y_src.unsqueeze(-1)
@@ -54,11 +54,11 @@ class NanoTabPFNModel(nn.Module):
 
 
 class FeatureEncoder(nn.Module):
-    def __init__(self, embedding_size: int):
+    def __init__(self, embedding_size):
         super().__init__()
         self.linear_layer = nn.Linear(1, embedding_size)
 
-    def forward(self, x: torch.Tensor, train_test_split_index: int) -> torch.Tensor:
+    def forward(self, x, train_test_split_index):
         x = x.unsqueeze(-1)
         mean = torch.mean(x[:, :train_test_split_index], dim=1, keepdims=True)
         std = torch.std(x[:, :train_test_split_index], dim=1, keepdims=True) + 1e-8
@@ -68,11 +68,11 @@ class FeatureEncoder(nn.Module):
 
 
 class TargetEncoder(nn.Module):
-    def __init__(self, embedding_size: int):
+    def __init__(self, embedding_size):
         super().__init__()
         self.linear_layer = nn.Linear(1, embedding_size)
 
-    def forward(self, y_train: torch.Tensor, num_rows: int) -> torch.Tensor:
+    def forward(self, y_train, num_rows):
         mean = torch.mean(y_train, axis=1, keepdim=True)
         padding = mean.repeat(1, num_rows - y_train.shape[1], 1)
         y = torch.cat([y_train, padding], dim=1)
@@ -84,11 +84,11 @@ class TransformerEncoderLayer(nn.Module):
 
     def __init__(
         self,
-        embedding_size: int,
-        nhead: int,
-        mlp_hidden_size: int,
-        layer_norm_eps: float = 1e-5,
-        batch_first: bool = True,
+        embedding_size,
+        nhead,
+        mlp_hidden_size,
+        layer_norm_eps = 1e-5,
+        batch_first = True,
         device=None,
         dtype=None,
     ):
@@ -107,7 +107,7 @@ class TransformerEncoderLayer(nn.Module):
         self.norm2 = LayerNorm(embedding_size, eps=layer_norm_eps, device=device, dtype=dtype)
         self.norm3 = LayerNorm(embedding_size, eps=layer_norm_eps, device=device, dtype=dtype)
 
-    def forward(self, src: torch.Tensor, train_test_split_index: int, num_mem_chunks: int = 1) -> torch.Tensor:
+    def forward(self, src, train_test_split_index, num_mem_chunks = 1):
         batch_size, rows_size, col_size, embedding_size = src.shape
         src = src.reshape(batch_size * rows_size, col_size, embedding_size)
 
@@ -151,10 +151,10 @@ class TransformerEncoderLayer(nn.Module):
         return src
 
 
-def memory_chunking(num_mem_chunks: int) -> callable:
+def memory_chunking(num_mem_chunks):
 
-    def decorator(func: Callable[[torch.Tensor], torch.Tensor]) -> Callable[[torch.Tensor], torch.Tensor]:
-        def wrapper(x: torch.Tensor) -> torch.Tensor:
+    def decorator(func):
+        def wrapper(x):
             if num_mem_chunks <= 1 or x.shape[0] == 0:
                 return func(x)
             elif torch.is_grad_enabled():
@@ -177,10 +177,10 @@ def memory_chunking(num_mem_chunks: int) -> callable:
 
 
 class Decoder(nn.Module):
-    def __init__(self, embedding_size: int, mlp_hidden_size: int, num_outputs: int):
+    def __init__(self, embedding_size, mlp_hidden_size, num_outputs):
         super().__init__()
         self.linear1 = nn.Linear(embedding_size, mlp_hidden_size)
         self.linear2 = nn.Linear(mlp_hidden_size, num_outputs)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x):
         return self.linear2(F.gelu(self.linear1(x)))

--- a/tfmplayground/models/nanotabpfn.py
+++ b/tfmplayground/models/nanotabpfn.py
@@ -1,4 +1,3 @@
-from collections.abc import Callable
 
 import torch
 import torch.nn.functional as F

--- a/tfmplayground/models/nanotabpfn.py
+++ b/tfmplayground/models/nanotabpfn.py
@@ -12,7 +12,6 @@ class NanoTabPFNModel(nn.Module):
     def __init__(
         self, embedding_size: int, num_attention_heads: int, mlp_hidden_size: int, num_layers: int, num_outputs: int
     ):
-        """Initializes the feature/target encoder, transformer blocks and decoder"""
         super().__init__()
         self.embedding_size = embedding_size
         self.num_attention_heads = num_attention_heads
@@ -29,30 +28,6 @@ class NanoTabPFNModel(nn.Module):
         self.decoder = Decoder(embedding_size, mlp_hidden_size, num_outputs)
 
     def forward(self, *args, **kwargs) -> torch.Tensor:
-        """
-        Provides two interfaces:
-        model(X_train, y_train, X_test)
-            Args:
-                X_train: (torch.Tensor) a tensor of shape (batch_size, num_train_datapoints, num_features)
-                y_train: (torch.Tensor) a tensor of shape (batch_size, num_train_datapoints, 1)
-                X_test: (torch.Tensor) a tensor of shape (batch_size, num_test_datapoints, num_features)
-
-        model((x,y), train_test_split_index)
-            Args:
-                x: (torch.Tensor) a tensor of shape (batch_size, num_datapoints, num_features)
-                y: (torch.Tensor) a tensor of shape (batch_size, num_train_datapoints, 1)
-
-
-        The former is similar to the sklearn interface.
-        In the latter x is the concatenation of X_train and X_test, y is y_train and
-        train_test_split_index is the length of X_train.
-        Our model internally works with the latter representation, so we convert the former into
-        the latter and forward it to _forward.
-
-        Returns:
-            (torch.Tensor) a tensor of shape (batch_size, num_test_datapoints, num_classes),
-                           which represent the predicted logits
-        """
         if len(args) == 3:
             x = args[0]
             if args[2] is not None:
@@ -80,22 +55,10 @@ class NanoTabPFNModel(nn.Module):
 
 class FeatureEncoder(nn.Module):
     def __init__(self, embedding_size: int):
-        """Creates the linear layer that we will use to embed our features."""
         super().__init__()
         self.linear_layer = nn.Linear(1, embedding_size)
 
     def forward(self, x: torch.Tensor, train_test_split_index: int) -> torch.Tensor:
-        """
-        Normalizes all the features based on the mean and std of the features of the training data,
-        clips them between -100 and 100, then applies a linear layer to embed the features.
-
-        Args:
-            x: (torch.Tensor) a tensor of shape (batch_size, num_rows, num_features)
-            train_test_split_index: (int) the number of datapoints in X_train
-        Returns:
-            (torch.Tensor) a tensor of shape (batch_size, num_rows, num_features, embedding_size), representing
-                           the embeddings of the features
-        """
         x = x.unsqueeze(-1)
         mean = torch.mean(x[:, :train_test_split_index], dim=1, keepdims=True)
         std = torch.std(x[:, :train_test_split_index], dim=1, keepdims=True) + 1e-8
@@ -106,21 +69,10 @@ class FeatureEncoder(nn.Module):
 
 class TargetEncoder(nn.Module):
     def __init__(self, embedding_size: int):
-        """Creates the linear layer that we will use to embed our targets."""
         super().__init__()
         self.linear_layer = nn.Linear(1, embedding_size)
 
     def forward(self, y_train: torch.Tensor, num_rows: int) -> torch.Tensor:
-        """
-        Pads up y_train to the full length of y using the mean per dataset and then embeds it using a linear layer
-
-        Args:
-            y_train: (torch.Tensor) a tensor of shape (batch_size, num_train_datapoints, 1)
-            num_rows: (int) the full length of y
-        Returns:
-            (torch.Tensor) a tensor of shape (batch_size, num_rows, 1, embedding_size), representing
-                           the embeddings of the targets
-        """
         mean = torch.mean(y_train, axis=1, keepdim=True)
         padding = mean.repeat(1, num_rows - y_train.shape[1], 1)
         y = torch.cat([y_train, padding], dim=1)
@@ -129,9 +81,6 @@ class TargetEncoder(nn.Module):
 
 
 class TransformerEncoderLayer(nn.Module):
-    """
-    Modified version of older version of https://github.com/pytorch/pytorch/blob/v2.6.0/torch/nn/modules/transformer.py#L630
-    """
 
     def __init__(
         self,
@@ -159,20 +108,6 @@ class TransformerEncoderLayer(nn.Module):
         self.norm3 = LayerNorm(embedding_size, eps=layer_norm_eps, device=device, dtype=dtype)
 
     def forward(self, src: torch.Tensor, train_test_split_index: int, num_mem_chunks: int = 1) -> torch.Tensor:
-        """
-        Takes the embeddings of the table as input and applies self-attention between features
-        and self-attention between datapoints followed by a simple 2 layer MLP.
-
-        Args:
-            src: (torch.Tensor) a tensor of shape (batch_size, num_rows, num_features, embedding_size)
-                                that contains all the embeddings for all the cells in the table
-            train_test_split_index: (int) the length of X_train
-            num_mem_chunks: (int) Number of chunks that memory-intense operations will be split into.
-                                  Higher values use less memory but are slower. Needs to be set to 1
-                                  during training to get correct gradients.
-        Returns
-            (torch.Tensor) a tensor of shape (batch_size, num_rows, num_features, embedding_size)
-        """
         batch_size, rows_size, col_size, embedding_size = src.shape
         src = src.reshape(batch_size * rows_size, col_size, embedding_size)
 
@@ -217,13 +152,6 @@ class TransformerEncoderLayer(nn.Module):
 
 
 def memory_chunking(num_mem_chunks: int) -> callable:
-    """
-    This decorator will split the first dimension of the input into chunks and apply the wrapped function
-    to each chunk separately.
-    Args:
-        num_mem_chunks: (int) Number of chunks to split the input into, higher values use less memory but are slower.
-                          Needs to be set to 1 during training to disable chunking and get correct gradients.
-    """
 
     def decorator(func: Callable[[torch.Tensor], torch.Tensor]) -> Callable[[torch.Tensor], torch.Tensor]:
         def wrapper(x: torch.Tensor) -> torch.Tensor:
@@ -250,18 +178,9 @@ def memory_chunking(num_mem_chunks: int) -> callable:
 
 class Decoder(nn.Module):
     def __init__(self, embedding_size: int, mlp_hidden_size: int, num_outputs: int):
-        """Initializes the linear layers for use in the forward"""
         super().__init__()
         self.linear1 = nn.Linear(embedding_size, mlp_hidden_size)
         self.linear2 = nn.Linear(mlp_hidden_size, num_outputs)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """
-        Applies an MLP to the embeddings to get the logits
-
-        Args:
-            x: (torch.Tensor) a tensor of shape (batch_size, num_rows, embedding_size)
-        Returns:
-            (torch.Tensor) a tensor of shape (batch_size, num_rows, num_outputs)
-        """
         return self.linear2(F.gelu(self.linear1(x)))

--- a/tfmplayground/models/nanotabpfn.py
+++ b/tfmplayground/models/nanotabpfn.py
@@ -1,5 +1,3 @@
-import math
-import warnings
 from collections.abc import Callable
 
 import torch
@@ -34,7 +32,7 @@ class NanoTabPFNModel(nn.Module):
         elif len(args) == 1 and isinstance(args[0], tuple):
             return self._forward(*args, **kwargs)
 
-    def _forward(self, src, train_test_split_index, num_mem_chunks=1):
+    def _forward(self, src, train_test_split_index):
         x_src, y_src = src
         if len(y_src.shape) < len(x_src.shape):
             y_src = y_src.unsqueeze(-1)
@@ -102,11 +100,10 @@ class TransformerEncoderLayer(nn.Module):
         self.norm2 = LayerNorm(embedding_size, eps=layer_norm_eps, device=device, dtype=dtype)
         self.norm3 = LayerNorm(embedding_size, eps=layer_norm_eps, device=device, dtype=dtype)
 
-    def forward(self, src, train_test_split_index, num_mem_chunks=1):
+    def forward(self, src, train_test_split_index):
         batch_size, rows_size, col_size, embedding_size = src.shape
         src = src.reshape(batch_size * rows_size, col_size, embedding_size)
 
-        @memory_chunking(num_mem_chunks)
         def feature_attention(x):
             return self.self_attention_between_features(x, x, x)[0] + x
 
@@ -116,7 +113,6 @@ class TransformerEncoderLayer(nn.Module):
         src = src.transpose(1, 2)
         src = src.reshape(batch_size * col_size, rows_size, embedding_size)
 
-        @memory_chunking(num_mem_chunks)
         def datapoint_attention(x):
             x_left = self.self_attention_between_datapoints(
                 x[:, :train_test_split_index],
@@ -136,7 +132,6 @@ class TransformerEncoderLayer(nn.Module):
         src = self.norm2(src)
         src = src.reshape(-1, embedding_size)
 
-        @memory_chunking(num_mem_chunks)
         def mlp(x):
             return self.linear2(F.gelu(self.linear1(x))) + x
 
@@ -144,29 +139,6 @@ class TransformerEncoderLayer(nn.Module):
         src = src.reshape(batch_size, rows_size, col_size, embedding_size)
         src = self.norm3(src)
         return src
-
-
-def memory_chunking(num_mem_chunks):
-
-    def decorator(func):
-        def wrapper(x):
-            if num_mem_chunks <= 1 or x.shape[0] == 0:
-                return func(x)
-            elif torch.is_grad_enabled():
-                warnings.warn(
-                    "Memory chunking is disabled since gradient computation is enabled to avoid incorrect gradients. "
-                    "Please use `with torch.no_grad():` during inference to enable chunking.",
-                    stacklevel=2,
-                )
-                return func(x)
-            chunk_size = max(1, math.ceil(x.shape[0] / num_mem_chunks))
-            for x_split in torch.split(x, split_size_or_sections=chunk_size, dim=0):
-                x_split[:] = func(x_split)
-            return x
-
-        return wrapper
-
-    return decorator
 
 
 class Decoder(nn.Module):

--- a/tfmplayground/models/nanotabpfn.py
+++ b/tfmplayground/models/nanotabpfn.py
@@ -28,7 +28,6 @@ class NanoTabPFNModel(nn.Module):
             )
         self.decoder = Decoder(embedding_size, mlp_hidden_size, num_outputs)
 
-    # TODO: consider getting rid of this and just provide a single interface
     def forward(self, *args, **kwargs) -> torch.Tensor:
         """
         Provides two interfaces:
@@ -55,40 +54,26 @@ class NanoTabPFNModel(nn.Module):
                            which represent the predicted logits
         """
         if len(args) == 3:
-            # case model(train_x, train_y, test_x)
             x = args[0]
             if args[2] is not None:
                 x = torch.cat((x, args[2]), dim=1)
             return self._forward((x, args[1]), train_test_split_index=args[0].shape[1], **kwargs)
         elif len(args) == 1 and isinstance(args[0], tuple):
-            # case model((x,y), train_test_split_index=None)
             return self._forward(*args, **kwargs)
 
     def _forward(
         self, src: tuple[torch.Tensor, torch.Tensor], train_test_split_index: int, num_mem_chunks: int = 1
     ) -> torch.Tensor:
         x_src, y_src = src
-        # we expect the labels to look like (batches, num_train_datapoints, 1),
-        # so we add the last dimension if it is missing
         if len(y_src.shape) < len(x_src.shape):
             y_src = y_src.unsqueeze(-1)
-        # from here on B=Batches, R=Rows, C=Columns, E=embedding size
-        # converts scalar values to embeddings, so (B,R,C-1) -> (B,R,C-1,E)
         x_src = self.feature_encoder(x_src, train_test_split_index)
         num_rows = x_src.shape[1]
-        # padds the y_train up to y by using the mean,
-        # then converts scalar values to embeddings (B,R,1,E)
         y_src = self.target_encoder(y_src, num_rows)
-        # concatenates the feature embeddings with the target embeddings
-        # to give us the full table of embeddings (B,R,C,E))
         src = torch.cat([x_src, y_src], 2)
-        # repeatedly applies the transformer block on (B,R,C,E)
         for block in self.transformer_blocks:
             src = block(src, train_test_split_index=train_test_split_index)
-        # selects the target embeddings (B,num_targets,1,E)
         output = src[:, train_test_split_index:, -1, :]
-        # runs the embeddings through the decoder to get
-        # the logits of our predictions (B,num_targets,num_classes)
         output = self.decoder(output)
         return output
 
@@ -113,7 +98,7 @@ class FeatureEncoder(nn.Module):
         """
         x = x.unsqueeze(-1)
         mean = torch.mean(x[:, :train_test_split_index], dim=1, keepdims=True)
-        std = torch.std(x[:, :train_test_split_index], dim=1, keepdims=True) + 1e-8  # TODO: maybe change the constant
+        std = torch.std(x[:, :train_test_split_index], dim=1, keepdims=True) + 1e-8
         x = (x - mean) / std
         x = torch.clip(x, min=-100, max=100)
         return self.linear_layer(x)
@@ -136,7 +121,6 @@ class TargetEncoder(nn.Module):
             (torch.Tensor) a tensor of shape (batch_size, num_rows, 1, embedding_size), representing
                            the embeddings of the targets
         """
-        # nan padding & nan handler instead?
         mean = torch.mean(y_train, axis=1, keepdim=True)
         padding = mean.repeat(1, num_rows - y_train.shape[1], 1)
         y = torch.cat([y_train, padding], dim=1)
@@ -190,7 +174,6 @@ class TransformerEncoderLayer(nn.Module):
             (torch.Tensor) a tensor of shape (batch_size, num_rows, num_features, embedding_size)
         """
         batch_size, rows_size, col_size, embedding_size = src.shape
-        # attention between features
         src = src.reshape(batch_size * rows_size, col_size, embedding_size)
 
         @memory_chunking(num_mem_chunks)
@@ -200,19 +183,16 @@ class TransformerEncoderLayer(nn.Module):
         src = feature_attention(src)
         src = src.reshape(batch_size, rows_size, col_size, embedding_size)
         src = self.norm1(src)
-        # attention between datapoints
         src = src.transpose(1, 2)
         src = src.reshape(batch_size * col_size, rows_size, embedding_size)
 
         @memory_chunking(num_mem_chunks)
         def datapoint_attention(x):
-            # training data attends to itself
             x_left = self.self_attention_between_datapoints(
                 x[:, :train_test_split_index],
                 x[:, :train_test_split_index],
                 x[:, :train_test_split_index],
             )[0]
-            # test data attends to the training data
             x_right = self.self_attention_between_datapoints(
                 x[:, train_test_split_index:],
                 x[:, :train_test_split_index],
@@ -224,7 +204,6 @@ class TransformerEncoderLayer(nn.Module):
         src = src.reshape(batch_size, col_size, rows_size, embedding_size)
         src = src.transpose(2, 1)
         src = self.norm2(src)
-        # MLP after attention
         src = src.reshape(-1, embedding_size)
 
         @memory_chunking(num_mem_chunks)
@@ -261,7 +240,7 @@ def memory_chunking(num_mem_chunks: int) -> callable:
             for x_split in torch.split(x, split_size_or_sections=chunk_size, dim=0):
                 x_split[:] = func(
                     x_split
-                )  # in-place modification to save memory, will cause wrong gradients if used during training
+                )
             return x
 
         return wrapper

--- a/tfmplayground/train.py
+++ b/tfmplayground/train.py
@@ -5,10 +5,7 @@ import schedulefree
 import torch
 from pfns.bar_distribution import FullSupportBarDistribution
 from torch import nn
-from torch.utils.data import DataLoader
 
-from tfmplayground.callbacks import Callback
-from tfmplayground.models.nanotabpfn import NanoTabPFNModel
 from tfmplayground.utils import get_default_device
 
 

--- a/tfmplayground/train.py
+++ b/tfmplayground/train.py
@@ -25,25 +25,6 @@ def train(
     multi_gpu: bool = False,
     run_name: str = "tfmplayground",
 ):
-    """
-    Trains our model on the given prior using the given criterion.
-
-    Args:
-        model: (NanoTabPFNModel) our PyTorch model
-        prior: (DataLoader) torch-compatible dataloader
-        criterion: (nn.CrossEntropyLoss | FullSupportBarDistribution) our loss criterion
-        epochs: (int) the number of epochs we train for,
-            the number of steps that constitute an epoch are decided by the prior
-        accumulate_gradients: (int) the number of gradients to accumulate before updating the weights
-        device: (torch.device) the device we are using
-        callbacks: A list of callback instances to execute at the end of each epoch. These can be used for
-            logging, validation, or other custom actions.
-        ckpt (Dict[str, torch.Tensor], optional): A checkpoint dictionary containing the model and optimizer states,
-            as well as the last completed epoch. If provided, training resumes from this checkpoint.
-
-    Returns:
-        (torch.Tensor) a tensor of shape (num_rows, batch_size, num_features, embedding_size)
-    """
     work_dir = "workdir/" + run_name
     os.makedirs(work_dir, exist_ok=True)
     if multi_gpu:

--- a/tfmplayground/train.py
+++ b/tfmplayground/train.py
@@ -13,17 +13,17 @@ from tfmplayground.utils import get_default_device
 
 
 def train(
-    model: NanoTabPFNModel,
-    prior: DataLoader,
-    criterion: nn.CrossEntropyLoss | FullSupportBarDistribution,
-    epochs: int,
-    accumulate_gradients: int = 1,
-    lr: float = 1e-4,
-    device: torch.device = None,
-    callbacks: list[Callback] = None,
-    ckpt: dict[str, torch.Tensor] = None,
-    multi_gpu: bool = False,
-    run_name: str = "tfmplayground",
+    model,
+    prior,
+    criterion,
+    epochs,
+    accumulate_gradients = 1,
+    lr = 1e-4,
+    device = None,
+    callbacks = None,
+    ckpt = None,
+    multi_gpu = False,
+    run_name = "tfmplayground",
 ):
     work_dir = "workdir/" + run_name
     os.makedirs(work_dir, exist_ok=True)

--- a/tfmplayground/train.py
+++ b/tfmplayground/train.py
@@ -64,7 +64,7 @@ def train(
     try:
         for epoch in range(ckpt["epoch"] + 1 if ckpt else 1, epochs + 1):
             epoch_start_time = time.time()
-            model.train()  # Turn on the train mode
+            model.train()
             optimizer.train()
             total_loss = 0.0
             for i, full_data in enumerate(prior):

--- a/tfmplayground/train.py
+++ b/tfmplayground/train.py
@@ -17,13 +17,13 @@ def train(
     prior,
     criterion,
     epochs,
-    accumulate_gradients = 1,
-    lr = 1e-4,
-    device = None,
-    callbacks = None,
-    ckpt = None,
-    multi_gpu = False,
-    run_name = "tfmplayground",
+    accumulate_gradients=1,
+    lr=1e-4,
+    device=None,
+    callbacks=None,
+    ckpt=None,
+    multi_gpu=False,
+    run_name="tfmplayground",
 ):
     work_dir = "workdir/" + run_name
     os.makedirs(work_dir, exist_ok=True)


### PR DESCRIPTION
a housekeeping pass before the big extension.

- removed **all** comments
- removed **all** docstrings
- removed **all** type annotations
- ruff formatting
- removed unused imports
- removed memory chunking
- fixed wandb log key
- fixed readme script name (will soon be gone but still...)

the cleanup commits are mechanical.

the one behavioural change is removing memory chunking — worth a closer look there.
