### PR TITLE
integrate nanotabicl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # TFM-Playground
 
+> **README must be updated — all checkpointing removed.**
+
 The purpose of this repository is to provide a fully open source playground for tabular foundation models.
 It contains a much smaller and simpler implementation of the TabPFNv2 architecture (nanoTabPFN) as well as a training loop, multiple interfaces to load prior data and an evaluation pipeline. We are planning to rapidly extend the repository with more features, prior interfaces and architectures.
 It is supposed to be a good starting point for students and researchers that are interested in learning about how Tabular foundation models work under the hood.

--- a/pretrain_classification.py
+++ b/pretrain_classification.py
@@ -6,7 +6,7 @@ from torch import nn
 from tfmplayground.callbacks import ConsoleLoggerCallback, WandbLoggerCallback
 from tfmplayground.evaluation import TABARENA_TASKS, TOY_TASKS_CLASSIFICATION, get_openml_predictions
 from tfmplayground.external_priors import PriorDumpDataLoader
-from tfmplayground.interface import NanoTabPFNClassifier
+from tfmplayground.interface import TabularClassifier
 from tfmplayground.models.nanotabpfn import NanoTabPFNModel
 from tfmplayground.train import train
 from tfmplayground.utils import get_default_device, set_randomness_seed
@@ -65,7 +65,7 @@ class ToyEvaluationLoggerCallback(ConsoleLoggerCallback):
         self.tasks = tasks
 
     def on_epoch_end(self, epoch: int, epoch_time: float, loss: float, model, **kwargs):
-        classifier = NanoTabPFNClassifier(model, device)
+        classifier = TabularClassifier(model, device)
         predictions = get_openml_predictions(model=classifier, tasks=self.tasks)
         scores = []
         for _dataset_name, (y_true, _y_pred, y_proba) in predictions.items():
@@ -82,7 +82,7 @@ class ProductionEvaluationLoggerCallback(WandbLoggerCallback):
         super().__init__(project, name, config, log_dir)
 
     def on_epoch_end(self, epoch: int, epoch_time: float, loss: float, model, **kwargs):
-        classifier = NanoTabPFNClassifier(model, device)
+        classifier = TabularClassifier(model, device)
         predictions = get_openml_predictions(model=classifier, classification=True, tasks=TABARENA_TASKS)
         scores = []
         log_metrics = {"epoch": epoch, "epoch_time": epoch_time, "mean_loss": loss}

--- a/pretrain_classification.py
+++ b/pretrain_classification.py
@@ -1,6 +1,5 @@
 import argparse
 
-import torch
 from sklearn.metrics import roc_auc_score
 from torch import nn
 
@@ -29,7 +28,6 @@ parser.add_argument(
     "--steps", type=int, default=100, help="number of steps that constitute one epoch (important for lr scheduler)"
 )
 parser.add_argument("--epochs", type=int, default=10000, help="number of epochs to train for")
-parser.add_argument("--loadcheckpoint", type=str, default=None, help="checkpoint from which to continue training")
 parser.add_argument("--multigpu", action="store_true", help="enable multi-GPU training using data parallelism")
 parser.add_argument(
     "--runname",
@@ -43,16 +41,12 @@ args = parser.parse_args()
 set_randomness_seed(2402)
 
 device = get_default_device()
-ckpt = None
-if args.loadcheckpoint:
-    ckpt = torch.load(args.loadcheckpoint)
 
 prior = PriorDumpDataLoader(
     filename=args.priordump,
     num_steps=args.steps,
     batch_size=args.batchsize,
     device=device,
-    starting_index=args.steps * (ckpt["epoch"] if ckpt else 0),
 )
 
 criterion = nn.CrossEntropyLoss()
@@ -64,9 +58,6 @@ model = NanoTabPFNModel(
     num_layers=args.layers,
     num_outputs=prior.max_num_classes,
 )
-
-if ckpt:
-    model.load_state_dict(ckpt["model"])
 
 
 class ToyEvaluationLoggerCallback(ConsoleLoggerCallback):
@@ -120,7 +111,5 @@ trained_model, loss = train(
     lr=args.lr,
     device=device,
     callbacks=callbacks,
-    ckpt=ckpt,
     multi_gpu=args.multigpu,
-    run_name=args.runname,
 )

--- a/pretrain_regression.py
+++ b/pretrain_regression.py
@@ -1,6 +1,5 @@
 import argparse
 
-import torch
 from pfns.bar_distribution import FullSupportBarDistribution
 from sklearn.metrics import r2_score
 
@@ -15,12 +14,6 @@ from tfmplayground.utils import get_default_device, make_global_bucket_edges, se
 parser = argparse.ArgumentParser()
 
 parser.add_argument("--priordump", type=str, default="50x3_1280k_regression.h5", help="path to the prior dump")
-parser.add_argument(
-    "--saveweights", type=str, default="nanotabpfn_weights.pth", help="path to save the trained model to"
-)
-parser.add_argument(
-    "--savebuckets", type=str, default="nanotabpfn_buckets.pth", help="path to save the bucket edges to"
-)
 parser.add_argument("--heads", type=int, default=6, help="number of attention heads")
 parser.add_argument("--embeddingsize", type=int, default=192, help="the size of the embeddings used for the cells")
 parser.add_argument("--hiddensize", type=int, default=768, help="size of the hidden layer of the mlps")
@@ -36,7 +29,6 @@ parser.add_argument(
     "--steps", type=int, default=100, help="number of steps that constitute one epoch (important for lr scheduler)"
 )
 parser.add_argument("--epochs", type=int, default=10000, help="number of epochs to train for")
-parser.add_argument("--loadcheckpoint", type=str, default=None, help="checkpoint from which to continue training")
 parser.add_argument("--n_buckets", type=int, default=100, help="number of buckets for the data loader")
 
 args = parser.parse_args()
@@ -44,16 +36,12 @@ args = parser.parse_args()
 set_randomness_seed(2402)
 
 device = get_default_device()
-ckpt = None
-if args.loadcheckpoint:
-    ckpt = torch.load(args.loadcheckpoint)
 
 prior = PriorDumpDataLoader(
     filename=args.priordump,
     num_steps=args.steps,
     batch_size=args.batchsize,
     device=device,
-    starting_index=args.steps * (ckpt["epoch"] if ckpt else 0),
 )
 
 model = NanoTabPFNModel(
@@ -69,14 +57,6 @@ bucket_edges = make_global_bucket_edges(
     n_buckets=args.n_buckets,
     device=device,
 )
-
-torch.save(
-    bucket_edges,
-    args.savebuckets,
-)
-
-if ckpt:
-    model.load_state_dict(ckpt["model"])
 
 dist = FullSupportBarDistribution(bucket_edges)
 
@@ -109,7 +89,4 @@ trained_model, loss = train(
     lr=args.lr,
     device=device,
     callbacks=callbacks,
-    ckpt=ckpt,
 )
-
-torch.save(trained_model.to("cpu").state_dict(), args.saveweights)

--- a/pretrain_regression.py
+++ b/pretrain_regression.py
@@ -6,7 +6,7 @@ from sklearn.metrics import r2_score
 from tfmplayground.callbacks import ConsoleLoggerCallback
 from tfmplayground.evaluation import TOY_TASKS_REGRESSION, get_openml_predictions
 from tfmplayground.external_priors import PriorDumpDataLoader
-from tfmplayground.interface import NanoTabPFNRegressor
+from tfmplayground.interface import TabularRegressor
 from tfmplayground.models.nanotabpfn import NanoTabPFNModel
 from tfmplayground.train import train
 from tfmplayground.utils import get_default_device, make_global_bucket_edges, set_randomness_seed
@@ -66,7 +66,7 @@ class EvaluationLoggerCallback(ConsoleLoggerCallback):
         self.tasks = tasks
 
     def on_epoch_end(self, epoch: int, epoch_time: float, loss: float, model, **kwargs):
-        regressor = NanoTabPFNRegressor(model, dist, device)
+        regressor = TabularRegressor(model, dist, device)
         predictions = get_openml_predictions(model=regressor, tasks=self.tasks)
         scores = []
         for _dataset_name, (y_true, y_pred, _) in predictions.items():

--- a/tfmplayground/__init__.py
+++ b/tfmplayground/__init__.py
@@ -1,3 +1,3 @@
-from tfmplayground.interface import NanoTabPFNClassifier, NanoTabPFNRegressor
+from tfmplayground.interface import TabularClassifier, TabularRegressor
 
-__all__ = ["NanoTabPFNClassifier", "NanoTabPFNRegressor"]
+__all__ = ["TabularClassifier", "TabularRegressor"]

--- a/tfmplayground/evaluation.py
+++ b/tfmplayground/evaluation.py
@@ -1,14 +1,12 @@
-import argparse
 
 import numpy as np
 import openml
 import torch
 from openml.config import set_root_cache_directory
 from openml.tasks import TaskType
-from sklearn.metrics import balanced_accuracy_score, r2_score, roc_auc_score
 from sklearn.preprocessing import LabelEncoder
 
-from tfmplayground.interface import NanoTabPFNClassifier, NanoTabPFNRegressor
+from tfmplayground.interface import TabularClassifier, TabularRegressor
 
 TOY_TASKS_REGRESSION = [
     362443,  # diabetes
@@ -80,7 +78,7 @@ TABARENA_TASKS = [
 @torch.no_grad()
 def get_openml_predictions(
     *,
-    model: NanoTabPFNRegressor | NanoTabPFNClassifier,
+    model: TabularRegressor | TabularClassifier,
     tasks: list[int] | str = "tabarena-v0.1",
     max_n_features: int = 500,
     max_n_samples: int = 10_000,
@@ -94,7 +92,7 @@ def get_openml_predictions(
     Returns true targets, predicted labels, and predicted probabilities for each dataset.
 
     Args:
-        model (NanoTabPFNRegressor | NanoTabPFNClassifier):
+        model (TabularRegressor | TabularClassifier):
             A scikit-learn compatible model or classifier to be evaluated.
         tasks (list[int] | str, optional):
             A list of OpenML task IDs or the name of a benchmark suite.
@@ -111,7 +109,7 @@ def get_openml_predictions(
             (true targets, predicted labels, predicted probabilities).
     """
     if classification is None:
-        classification = isinstance(model, NanoTabPFNClassifier)  # TODO: change this once we support different models
+        classification = isinstance(model, TabularClassifier)  # TODO: change this once we support different models
 
     if cache_directory is not None:
         set_root_cache_directory(cache_directory)
@@ -179,92 +177,3 @@ def get_openml_predictions(
     return dataset_predictions
 
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "-model_type",
-        type=str,
-        choices=["regression", "classification"],
-        required=True,
-        help="Whether to use the regressor or classifier model",
-    )
-    parser.add_argument(
-        "-checkpoint",
-        type=str,
-        default=None,
-        help="Path to load the model weights from. If None, default weights are used.",
-    )
-    parser.add_argument(
-        "-dist_path",
-        type=str,
-        default=None,
-        help="Path to load the bucket edges for the support bar distribution from. Only needed for regression.",
-    )
-    parser.add_argument(
-        "-tasks",
-        type=str,
-        default="tabarena-v0.1",
-        choices=["tabarena-v0.1", "toy_tasks"],
-        help="Which OpenML tasks to evaluate on.",
-    )
-    parser.add_argument(
-        "-cache_directory",
-        type=str,
-        default=None,
-        help="Directory to save OpenML data. If None, default cache path is used.",
-    )
-    parser.add_argument(
-        "-max_n_features",
-        type=int,
-        default=500,
-        help="Maximum number of features allowed for a task. Tasks exceeding this limit are skipped.",
-    )
-    parser.add_argument(
-        "-max_n_samples",
-        type=int,
-        default=10_000,
-        help="Maximum number of instances allowed for a task. Tasks exceeding this limit are skipped.",
-    )
-    parser.add_argument(
-        "-num_mem_chunks",
-        type=int,
-        default=8,
-        help="Chunks attention computation into `num_mem_chunks` many chunks to reduce memory usage.",
-    )
-    args = parser.parse_args()
-
-    if args.model_type == "classification":
-        model = NanoTabPFNClassifier(model=args.checkpoint, num_mem_chunks=args.num_mem_chunks)
-    else:
-        model = NanoTabPFNRegressor(model=args.checkpoint, dist=args.dist_path, num_mem_chunks=args.num_mem_chunks)
-    model.model.eval()
-
-    if args.tasks == "toy_tasks" and args.model_type == "regression":
-        tasks = TOY_TASKS_REGRESSION
-    elif args.tasks == "toy_tasks" and args.model_type == "classification":
-        tasks = TOY_TASKS_CLASSIFICATION
-    else:
-        tasks = args.tasks
-
-    predictions = get_openml_predictions(
-        model=model,
-        tasks=tasks,
-        max_n_features=args.max_n_features,
-        max_n_samples=args.max_n_samples,
-        classification=(args.model_type == "classification"),
-        cache_directory=args.cache_directory,
-    )
-
-    average_score = 0
-    for dataset_name, (y_true, y_pred, y_proba) in predictions.items():
-        if args.model_type == "classification":
-            acc = balanced_accuracy_score(y_true, y_pred)
-            auc = roc_auc_score(y_true, y_proba, multi_class="ovr")
-            average_score += auc
-            print(f"Dataset: {dataset_name} | ROC AUC: {auc:.4f} | Balanced Accuracy: {acc:.4f}")
-        else:
-            r2 = r2_score(y_true, y_pred)
-            average_score += r2
-            print(f"Dataset: {dataset_name} | R2: {r2:.4f}")
-    average_score /= len(predictions)
-    print(f"Average {'ROC AUC' if args.model_type == 'classification' else 'R2'}: {average_score:.4f}")

--- a/tfmplayground/interface.py
+++ b/tfmplayground/interface.py
@@ -8,11 +8,11 @@ from sklearn.impute import SimpleImputer
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import FunctionTransformer, OrdinalEncoder
 
-from tfmplayground.models.nanotabpfn import NanoTabPFNModel
+from tfmplayground.models import TabularFoundationModel
 from tfmplayground.utils import get_default_device
 
 
-# doing these as lambdas would cause NanoTabPFNClassifier to not be pickle-able,
+# doing these as lambdas would cause TabularClassifier to not be pickle-able,
 # which would cause issues if we want to run it inside the tabarena codebase
 def to_pandas(x):
     return pd.DataFrame(x) if not isinstance(x, pd.DataFrame) else x
@@ -69,12 +69,12 @@ def get_feature_preprocessor(X: np.ndarray | pd.DataFrame) -> ColumnTransformer:
     return preprocessor
 
 
-class NanoTabPFNClassifier:
+class TabularClassifier:
     """scikit-learn like interface"""
 
     def __init__(
         self,
-        model: NanoTabPFNModel,
+        model: TabularFoundationModel,
         device: None | str | torch.device = None,
         num_mem_chunks: int = 8,
     ):
@@ -115,12 +115,12 @@ class NanoTabPFNClassifier:
             return probabilities.to("cpu").numpy()
 
 
-class NanoTabPFNRegressor:
+class TabularRegressor:
     """scikit-learn like interface"""
 
     def __init__(
         self,
-        model: NanoTabPFNModel,
+        model: TabularFoundationModel,
         dist: FullSupportBarDistribution,
         device: str | torch.device | None = None,
         num_mem_chunks: int = 8,

--- a/tfmplayground/interface.py
+++ b/tfmplayground/interface.py
@@ -1,8 +1,5 @@
-import os
-
 import numpy as np
 import pandas as pd
-import requests
 import torch
 import torch.nn.functional as F
 from pfns.bar_distribution import FullSupportBarDistribution
@@ -13,22 +10,6 @@ from sklearn.preprocessing import FunctionTransformer, OrdinalEncoder
 
 from tfmplayground.models.nanotabpfn import NanoTabPFNModel
 from tfmplayground.utils import get_default_device
-
-
-def init_model_from_state_dict_file(file_path):
-    """
-    reads model architecture from state dict, instantiates the architecture and loads the weights
-    """
-    state_dict = torch.load(file_path, map_location=torch.device("cpu"))
-    model = NanoTabPFNModel(
-        num_attention_heads=state_dict["architecture"]["num_attention_heads"],
-        embedding_size=state_dict["architecture"]["embedding_size"],
-        mlp_hidden_size=state_dict["architecture"]["mlp_hidden_size"],
-        num_layers=state_dict["architecture"]["num_layers"],
-        num_outputs=state_dict["architecture"]["num_outputs"],
-    )
-    model.load_state_dict(state_dict["model"])
-    return model
 
 
 # doing these as lambdas would cause NanoTabPFNClassifier to not be pickle-able,
@@ -93,24 +74,12 @@ class NanoTabPFNClassifier:
 
     def __init__(
         self,
-        model: NanoTabPFNModel | str | None = None,
+        model: NanoTabPFNModel,
         device: None | str | torch.device = None,
         num_mem_chunks: int = 8,
     ):
         if device is None:
             device = get_default_device()
-        if model is None:
-            model = "checkpoints/nanotabpfn.pth"
-            if not os.path.isfile(model):
-                os.makedirs("checkpoints", exist_ok=True)
-                print("No cached model found, downloading model checkpoint.")
-                response = requests.get(
-                    "https://ml.informatik.uni-freiburg.de/research-artifacts/pfefferle/TFM-Playground/nanotabpfn_classifier.pth"
-                )
-                with open(model, "wb") as f:
-                    f.write(response.content)
-        if isinstance(model, str):
-            model = init_model_from_state_dict_file(model)
         self.model = model.to(device)
         self.model.num_mem_chunks = num_mem_chunks
         self.device = device
@@ -151,38 +120,13 @@ class NanoTabPFNRegressor:
 
     def __init__(
         self,
-        model: NanoTabPFNModel | str | None = None,
-        dist: FullSupportBarDistribution | str | None = None,
+        model: NanoTabPFNModel,
+        dist: FullSupportBarDistribution,
         device: str | torch.device | None = None,
         num_mem_chunks: int = 8,
     ):
         if device is None:
             device = get_default_device()
-        if model is None:
-            os.makedirs("checkpoints", exist_ok=True)
-            model = "checkpoints/nanotabpfn_regressor.pth"
-            dist = "checkpoints/nanotabpfn_regressor_buckets.pth"
-            if not os.path.isfile(model):
-                print("No cached model found, downloading model checkpoint.")
-                response = requests.get(
-                    "https://ml.informatik.uni-freiburg.de/research-artifacts/pfefferle/TFM-Playground/nanotabpfn_regressor.pth"
-                )
-                with open(model, "wb") as f:
-                    f.write(response.content)
-            if not os.path.isfile(dist):
-                print("No cached bucket edges found, downloading bucket edges.")
-                response = requests.get(
-                    "https://ml.informatik.uni-freiburg.de/research-artifacts/pfefferle/TFM-Playground/nanotabpfn_regressor_buckets.pth"
-                )
-                with open(dist, "wb") as f:
-                    f.write(response.content)
-        if isinstance(model, str):
-            model = init_model_from_state_dict_file(model)
-
-        if isinstance(dist, str):
-            bucket_edges = torch.load(dist, map_location=device)
-            dist = FullSupportBarDistribution(bucket_edges).float()
-
         self.model = model.to(device)
         self.model.num_mem_chunks = num_mem_chunks
         self.device = device

--- a/tfmplayground/models/__init__.py
+++ b/tfmplayground/models/__init__.py
@@ -1,4 +1,5 @@
 from tfmplayground.models.base import TabularFoundationModel
+from tfmplayground.models.nanotabicl import NanoTabICLv2
 from tfmplayground.models.nanotabpfn import NanoTabPFNModel
 
-__all__ = ["TabularFoundationModel", "NanoTabPFNModel"]
+__all__ = ["TabularFoundationModel", "NanoTabPFNModel", "NanoTabICLv2"]

--- a/tfmplayground/models/nanotabicl.py
+++ b/tfmplayground/models/nanotabicl.py
@@ -1,3 +1,35 @@
+# Vendored from https://github.com/soda-inria/nanotabicl, adapted to TabularFoundationModel.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# BSD 3-Clause License
+#
+# Copyright (c) 2025, Soda team @ Inria
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 import typing, math, torch, torch.nn as nn
 
 from tfmplayground.models.base import TabularFoundationModel

--- a/tfmplayground/models/nanotabicl.py
+++ b/tfmplayground/models/nanotabicl.py
@@ -1,7 +1,9 @@
 import typing, math, torch, torch.nn as nn
 
+from tfmplayground.models.base import TabularFoundationModel
 
-class NanoTabICLv2(nn.Module):
+
+class NanoTabICLv2(TabularFoundationModel):
     def __init__(self, max_classes: int, out_dim: int, embed_dim: int = 128,
                  col_num_blocks: int = 3, row_num_blocks: int = 3, icl_num_blocks: int = 12,
                  col_nhead: int = 8, row_nhead: int = 8, icl_nhead: int = 8,
@@ -28,7 +30,9 @@ class NanoTabICLv2(nn.Module):
         self.out_ln = nn.LayerNorm(icl_dim)
         self.out_mlp = get_mlp(icl_dim, icl_dim * 2, out_dim)
 
-    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    def forward(self, X_train: torch.Tensor, y_train: torch.Tensor, X_test: torch.Tensor) -> torch.Tensor:
+        x = torch.cat([X_train, X_test], dim=1)
+        y = y_train
         n_batch, n_rows, n_cols = x.shape
         n_batch, n_train = y.shape
 
@@ -163,11 +167,3 @@ class QASSMax(nn.Module):  # query-aware scalable softmax for better context len
         batch_size, num_heads, seq_len, head_dim = q.shape
         logn = q.new_tensor(math.log(max(1, n))).view(1, 1)
         return self.base_mlp(logn).view(1, num_heads, 1, head_dim) * (1 + torch.tanh(self.query_mlp(q))) * q
-
-
-if __name__ == '__main__':  # check that forward pass works
-    n_batch, n_train, n_test, n_cols = 2, 16, 8, 3
-    model = NanoTabICLv2(max_classes=10, out_dim=10)
-    x = torch.randn(n_batch, n_train + n_test, n_cols)
-    y = torch.randint(10, size=(n_batch, n_train))
-    print(f'{model(x,y).shape=}')

--- a/tfmplayground/models/nanotabicl.py
+++ b/tfmplayground/models/nanotabicl.py
@@ -1,0 +1,173 @@
+import typing, math, torch, torch.nn as nn
+
+
+class NanoTabICLv2(nn.Module):
+    def __init__(self, max_classes: int, out_dim: int, embed_dim: int = 128,
+                 col_num_blocks: int = 3, row_num_blocks: int = 3, icl_num_blocks: int = 12,
+                 col_nhead: int = 8, row_nhead: int = 8, icl_nhead: int = 8,
+                 feature_group_size: int = 3, n_cls_cols: int = 4, n_cls_rows: int = 128):
+        # classification: max_classes = out_dim (= 10 typically); regression: max_classes = 0, out_dim = n_quantiles
+        super().__init__()
+        self.feature_group_size = feature_group_size
+        icl_dim = embed_dim * n_cls_cols
+
+        self.x_embed = nn.Linear(feature_group_size, embed_dim)
+        self.y_embed_in = ClassEmbedding(max_classes, embed_dim) if max_classes > 0 else nn.Linear(1, embed_dim)
+        self.y_embed_icl = ClassEmbedding(max_classes, icl_dim) if max_classes > 0 else nn.Linear(1, icl_dim)
+
+        self.col_blocks = nn.ModuleList([
+            InducedTransformerBlock(embed_dim=embed_dim, num_heads=col_nhead, n_inducing=n_cls_rows, ssmax=True)
+            for _ in range(col_num_blocks)])
+        self.row_blocks = nn.ModuleList([
+            TransformerBlock(embed_dim=embed_dim, num_heads=row_nhead, use_rope=True) for _ in range(row_num_blocks)])
+        self.icl_blocks = nn.ModuleList([
+            TransformerBlock(embed_dim=icl_dim, num_heads=icl_nhead, ssmax=True) for _ in range(icl_num_blocks)])
+
+        self.row_cls_tokens = nn.Parameter(0.02 * torch.randn(1, 1, n_cls_cols, embed_dim))
+        self.row_ln = nn.LayerNorm(embed_dim)
+        self.out_ln = nn.LayerNorm(icl_dim)
+        self.out_mlp = get_mlp(icl_dim, icl_dim * 2, out_dim)
+
+    def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        n_batch, n_rows, n_cols = x.shape
+        n_batch, n_train = y.shape
+
+        # ----- Embedding: standardize -> repeated feature grouping -> x embedding -> add y embedding to train
+        x = (x - x[:, :n_train].mean(dim=1, keepdim=True)) / (x[:, :n_train].std(dim=1, unbiased=False, keepdim=True) + 1e-8)
+        idxs = torch.arange(n_cols, dtype=torch.long, device=x.device)
+        x = torch.stack([x[:, :, (idxs + (2 ** i - 1)) % n_cols] for i in range(self.feature_group_size)], dim=-1)
+        emb = self.x_embed(x)  # emb.shape = (n_batch, n_rows, n_cols, embed_dim)
+        emb[:, :n_train] += self.y_embed_in(y[:, :, None, None])
+
+        # ----- TF_col: induced self-attention within each column
+        for block in self.col_blocks:
+            emb = block.col_attn(emb, kv_max_idx=n_train)  # all rows only attend to training rows
+
+        # ----- TF_row: concat CLS tokens as extra columns -> row attention -> norm + merge cls tokens
+        emb = torch.cat([self.row_cls_tokens.expand(n_batch, n_rows, -1, -1), emb], dim=2)
+        for block in self.row_blocks[:-1]:
+            emb = block.row_attn(emb)
+        emb = self.row_blocks[-1].row_attn(emb, q_max_idx=self.row_cls_tokens.size(-2))  # need only the cls token values
+        emb = self.row_ln(emb).flatten(-2, -1)  # norm + merge cls tokens into one bigger token
+
+        # ----- TF_icl: add y embedding -> self-attention
+        # now emb.shape = (n_batch, n_rows, icl_dim)
+        emb[:, :n_train] += self.y_embed_icl(y[:, :, None])  # add y embeddings again
+        for block in self.icl_blocks[:-1]:
+            emb = block(emb, kv_max_idx=n_train)  # all rows only attend to training rows
+        emb = self.icl_blocks[-1](emb[:, n_train:], emb[:, :n_train])  # need only test predictions
+
+        return self.out_mlp(self.out_ln(emb))  # output MLP
+
+
+class ClassEmbedding(nn.Embedding):
+    def reset_parameters(self) -> None:  # change init to match one-hot + linear
+        nn.init.uniform_(self.weight, -1/math.sqrt(self.num_embeddings), 1/math.sqrt(self.num_embeddings))
+
+    def forward(self, y: torch.Tensor) -> torch.Tensor:
+        return super().forward(y.squeeze(-1).long())
+
+
+def get_mlp(n_in: int, n_hidden: int, n_out: int):
+    return nn.Sequential(nn.Linear(n_in, n_hidden), nn.GELU(), nn.Linear(n_hidden, n_out))
+
+
+class TableAttnBase(nn.Module):  # base class with functions to apply attention on 2D tables instead of 1D sequences
+    def row_attn(self, q, kv=None, **kwargs):  # apply attention within each row separately
+        n_batch, n_rows, n_cols, embed_dim = q.shape
+        q, kv = (None if t is None else t.flatten(0, 1) for t in [q, kv])  # merge rows dim into batch dim
+        # apply attention -> unmerge rows dim from batch dim; dimension -2 might differ because of q_max_idx in kwargs
+        return self(q, kv, **kwargs).reshape(n_batch, n_rows, -1, embed_dim)
+
+    def col_attn(self, q, kv=None, **kwargs):  # apply attention within each column separately
+        return self.row_attn(q.transpose(1, 2), None if kv is None else kv.transpose(1, 2), **kwargs).transpose(1, 2)
+
+
+class InducedTransformerBlock(TableAttnBase):
+    def __init__(self, embed_dim: int, num_heads: int, n_inducing: int, ssmax: bool = False):
+        super().__init__()
+        self.tfm1 = TransformerBlock(embed_dim=embed_dim, num_heads=num_heads, ssmax=ssmax)
+        self.tfm2 = TransformerBlock(embed_dim=embed_dim, num_heads=num_heads)  # fixed nb of ind. vectors -> no ssmax
+        self.inducing_vectors = nn.Parameter(0.02 * torch.randn(1, n_inducing, embed_dim))
+
+    def forward(self, q, kv=None, q_max_idx: typing.Optional[int] = None, kv_max_idx: typing.Optional[int] = None):
+        kv = self.tfm1(self.inducing_vectors.expand(q.shape[0], -1, -1), q if kv is None else kv, kv_max_idx=kv_max_idx)
+        return self.tfm2(q, kv, q_max_idx=q_max_idx)
+
+
+class TransformerBlock(nn.MultiheadAttention, TableAttnBase):
+    def __init__(self, embed_dim: int, num_heads: int, use_rope: bool = False, ssmax: bool = False):
+        super().__init__(embed_dim=embed_dim, num_heads=num_heads)
+        self.rope = Rope(head_dim=embed_dim // num_heads, theta=100_000.0) if use_rope else None
+        self.ssmax_layer = QASSMax(num_heads=num_heads, head_dim=embed_dim // num_heads) if ssmax else None
+        self.mlp = get_mlp(embed_dim, embed_dim * 2, embed_dim)
+        self.ln_attn = nn.LayerNorm(embed_dim)
+        self.ln_mlp = nn.LayerNorm(embed_dim)
+
+    def forward(self, q, kv=None, q_max_idx: typing.Optional[int] = None, kv_max_idx: typing.Optional[int] = None):
+        # q.shape: (batch_size, q_len, embed_dim), kv.shape: (batch_size, kv_len, embed_dim)
+        x, q = q, self.ln_attn(q)
+        kv = q if kv is None else self.ln_attn(kv)
+        if kv_max_idx is not None: kv = kv[..., :kv_max_idx, :]
+        if q_max_idx is not None: x, q = x[..., :q_max_idx, :], q[..., :q_max_idx, :]
+
+        x = x + self.attn(q, kv)
+        del q, kv  # save memory during inference
+        return x + self.mlp(self.ln_mlp(x))  # we use pre-norm here and for the attention as well
+
+    def attn(self, q: torch.Tensor, k: torch.Tensor) -> torch.Tensor:
+        # Joint projection of (q, k, v), then transpose heads to (batch_size, num_heads, len, head_dim)
+        q, k, v = nn.functional._in_projection_packed(q, k, k, self.in_proj_weight, self.in_proj_bias)
+        q, k, v = (t.unflatten(-1, (self.num_heads, self.head_dim)).transpose(-3, -2) for t in [q, k, v])
+
+        q = q if self.ssmax_layer is None else self.ssmax_layer(q=q, n=k.size(-2))  # SSMax (optional)
+        q, k = (t if self.rope is None else self.rope(t) for t in [q, k])  # RoPE (optional)
+
+        # attention with heads in batch dim (maybe needed for FlashAttention) -> put the head dim back -> out projection
+        attn_output = nn.functional.scaled_dot_product_attention(*[t.flatten(0, 1) for t in (q, k, v)]).view(q.shape)
+        del q, k, v  # save memory during inference
+        return self.out_proj(attn_output.transpose(-3, -2).flatten(-2, -1))  # (batch_size, q_len, embed_dim)
+
+
+class Rope(nn.Module):  # rotary positional encoding
+    def __init__(self, head_dim: int, theta: float):
+        super().__init__()
+        self.half = head_dim // 2
+        self.register_buffer("inv_freq", theta ** torch.linspace(0.0, -1.0, self.half + 1)[:-1], persistent=False)
+        self.register_buffer("sin", torch.empty(0), persistent=False)
+        self.register_buffer("cos", torch.empty(0), persistent=False)
+
+    @torch.autocast("cuda", enabled=False)
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        batch_size, num_heads, seq_len, head_dim = x.shape
+
+        if self.cos.numel() == 0 or self.cos.device != x.device or self.cos.size(0) < seq_len:  # need to extend cache
+            pos = torch.arange(seq_len, device=x.device, dtype=self.inv_freq.dtype)  # (seq_len,)
+            angles = pos[:, None] * self.inv_freq[None, :]  # (seq_len, half_head_dim)
+            self.sin, self.cos = angles.sin(), angles.cos()  # (seq_len, half_head_dim)
+
+        sin, cos = self.sin[:seq_len], self.cos[:seq_len]
+        x1, x2 = x[..., :self.half], x[..., self.half:]  # (batch_size, num_heads, seq_len, half_head_dim)
+        return torch.cat([x1 * cos - x2 * sin, x1 * sin + x2 * cos], dim=-1).to(x.dtype)
+
+
+class QASSMax(nn.Module):  # query-aware scalable softmax for better context length scaling
+    def __init__(self, num_heads: int, head_dim: int, n_hidden: int = 64):
+        super().__init__()
+        self.base_mlp = get_mlp(1, n_hidden, num_heads * head_dim)
+        self.query_mlp = get_mlp(head_dim, n_hidden, head_dim)
+        nn.init.zeros_(self.query_mlp[-1].weight)  # ensures initial modulation is zero
+        nn.init.zeros_(self.query_mlp[-1].bias)
+
+    def forward(self, q: torch.Tensor, n: int) -> torch.Tensor:
+        batch_size, num_heads, seq_len, head_dim = q.shape
+        logn = q.new_tensor(math.log(max(1, n))).view(1, 1)
+        return self.base_mlp(logn).view(1, num_heads, 1, head_dim) * (1 + torch.tanh(self.query_mlp(q))) * q
+
+
+if __name__ == '__main__':  # check that forward pass works
+    n_batch, n_train, n_test, n_cols = 2, 16, 8, 3
+    model = NanoTabICLv2(max_classes=10, out_dim=10)
+    x = torch.randn(n_batch, n_train + n_test, n_cols)
+    y = torch.randint(10, size=(n_batch, n_train))
+    print(f'{model(x,y).shape=}')

--- a/tfmplayground/train.py
+++ b/tfmplayground/train.py
@@ -1,4 +1,3 @@
-import os
 import time
 
 import schedulefree
@@ -21,9 +20,7 @@ def train(
     lr: float = 1e-4,
     device: torch.device = None,
     callbacks: list[Callback] = None,
-    ckpt: dict[str, torch.Tensor] = None,
     multi_gpu: bool = False,
-    run_name: str = "tfmplayground",
 ):
     """
     Trains our model on the given prior using the given criterion.
@@ -38,14 +35,10 @@ def train(
         device: (torch.device) the device we are using
         callbacks: A list of callback instances to execute at the end of each epoch. These can be used for
             logging, validation, or other custom actions.
-        ckpt (Dict[str, torch.Tensor], optional): A checkpoint dictionary containing the model and optimizer states,
-            as well as the last completed epoch. If provided, training resumes from this checkpoint.
 
     Returns:
         (torch.Tensor) a tensor of shape (num_rows, batch_size, num_features, embedding_size)
     """
-    work_dir = "workdir/" + run_name
-    os.makedirs(work_dir, exist_ok=True)
     if multi_gpu:
         model = nn.DataParallel(model)
     if callbacks is None:
@@ -54,15 +47,13 @@ def train(
         device = get_default_device()
     model.to(device)
     optimizer = schedulefree.AdamWScheduleFree(model.parameters(), lr=lr, weight_decay=0.0)
-    if ckpt:
-        optimizer.load_state_dict(ckpt["optimizer"])
     classification_task = isinstance(criterion, nn.CrossEntropyLoss)
     regression_task = not classification_task
 
     assert prior.num_steps % accumulate_gradients == 0, "num_steps must be divisible by accumulate_gradients"
 
     try:
-        for epoch in range(ckpt["epoch"] + 1 if ckpt else 1, epochs + 1):
+        for epoch in range(1, epochs + 1):
             epoch_start_time = time.time()
             model.train()  # Turn on the train mode
             optimizer.train()
@@ -102,20 +93,6 @@ def train(
             mean_loss = total_loss / len(prior)
             model.eval()
             optimizer.eval()
-
-            training_state = {
-                "epoch": epoch,
-                "architecture": {
-                    "num_layers": int((model.module if multi_gpu else model).num_layers),
-                    "embedding_size": int((model.module if multi_gpu else model).embedding_size),
-                    "num_attention_heads": int((model.module if multi_gpu else model).num_attention_heads),
-                    "mlp_hidden_size": int((model.module if multi_gpu else model).mlp_hidden_size),
-                    "num_outputs": int((model.module if multi_gpu else model).num_outputs),
-                },
-                "model": (model.module if multi_gpu else model).state_dict(),
-                "optimizer": optimizer.state_dict(),
-            }
-            torch.save(training_state, work_dir + "/latest_checkpoint.pth")
 
             for callback in callbacks:
                 if type(criterion) is FullSupportBarDistribution:


### PR DESCRIPTION
integrate [nanotabicl](https://github.com/soda-inria/nanotabicl)
- `model.py` as `tfmplayground/models/nanotabicl.py`
- `TabularFoundationModel` base (forward now takes `(X_train, y_train, X_test)`)
- supports both classification and regression.

neutralise the interfaces
- `NanoTabPFNClassifier` → `TabularClassifier`
- `NanoTabPFNRegressor` → `TabularRegressor`

remove **all** checkpointing to be implemented and updated later
- dropped save/load/resume in `train.py`
- pretrain scripts
- download/loader in `interface.py`

added readme disclaimer
- we will do it at the end :)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ktQq9zrN3Z3weL4L8y6Qj
