### PR TITLE
integrate nanotabdpt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,9 @@ select = [
     "B",   # flake8-bugbear
     "SIM", # flake8-simplify
 ]
-ignore = ["E741"]
+ignore = [
+    "E741",  # ambiguous variable name
+]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ select = [
     "B",   # flake8-bugbear
     "SIM", # flake8-simplify
 ]
-ignore = []
+ignore = ["E741"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/tfmplayground/configs/nanotabpfn_classifier.yaml
+++ b/tfmplayground/configs/nanotabpfn_classifier.yaml
@@ -8,6 +8,4 @@ accumulate: 1
 lr: 0.0001
 steps: 100
 epochs: 10000
-loadcheckpoint: null
 multigpu: false
-runname: nanotabpfn

--- a/tfmplayground/configs/nanotabpfn_regressor.yaml
+++ b/tfmplayground/configs/nanotabpfn_regressor.yaml
@@ -1,6 +1,4 @@
 priordump: 50x3_1280k_regression.h5
-saveweights: nanotabpfn_weights.pth
-savebuckets: nanotabpfn_buckets.pth
 heads: 6
 embeddingsize: 192
 hiddensize: 768
@@ -10,5 +8,4 @@ accumulate: 1
 lr: 0.0001
 steps: 100
 epochs: 10000
-loadcheckpoint: null
 n_buckets: 100

--- a/tfmplayground/models/__init__.py
+++ b/tfmplayground/models/__init__.py
@@ -1,5 +1,6 @@
 from tfmplayground.models.base import TabularFoundationModel
+from tfmplayground.models.nanotabdpt import TabDPTModel
 from tfmplayground.models.nanotabicl import NanoTabICLv2
 from tfmplayground.models.nanotabpfn import NanoTabPFNModel
 
-__all__ = ["TabularFoundationModel", "NanoTabPFNModel", "NanoTabICLv2"]
+__all__ = ["TabularFoundationModel", "NanoTabPFNModel", "NanoTabICLv2", "TabDPTModel"]

--- a/tfmplayground/models/nanotabdpt.py
+++ b/tfmplayground/models/nanotabdpt.py
@@ -173,8 +173,8 @@ class TabDPTModel(TabularFoundationModel):
             B = src.shape[1]
             src = torch.cat([self.thinking_embed.unsqueeze(1).expand(n_think, B, -1), src], dim=0)
 
-        for i, layer in enumerate(self.transformer_encoder):
-            y_emb = self.y_encoders[i](y_src.unsqueeze(-1))
+        for l, layer in enumerate(self.transformer_encoder):
+            y_emb = self.y_encoders[l](y_src.unsqueeze(-1))
             if n_think > 0:
                 B = y_emb.shape[1]
                 y_emb = torch.cat([y_emb.new_zeros(n_think, B, y_emb.shape[-1]), y_emb], dim=0)

--- a/tfmplayground/models/nanotabdpt.py
+++ b/tfmplayground/models/nanotabdpt.py
@@ -186,8 +186,8 @@ class TabDPTModel(TabularFoundationModel):
         pred = self.head(src[eval_pos + n_think :].float())
         pred = pred.transpose(0, 1)
         if self.classification:
-            return pred[..., : self.n_out]
-        return pred[..., self.n_out :]
+            return pred[..., : self.n_out].contiguous()
+        return pred[..., self.n_out :].contiguous()
 
 
 class RMSNorm(nn.Module):

--- a/tfmplayground/models/nanotabdpt.py
+++ b/tfmplayground/models/nanotabdpt.py
@@ -1,3 +1,21 @@
+# Vendored from https://github.com/layer6ai-labs/TabDPT-inference (v1.2.0), adapted to
+# TabularFoundationModel. Modified from the original.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2024-2026 The Toronto-Dominion Bank and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import math
 from functools import wraps
 

--- a/tfmplayground/models/nanotabdpt.py
+++ b/tfmplayground/models/nanotabdpt.py
@@ -1,0 +1,341 @@
+from functools import wraps
+from typing import Literal
+import math
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn import LayerNorm, Linear
+from torch.nn.attention import SDPBackend, sdpa_kernel
+
+
+def generate_random_permutation(N, seed=None):
+    generator = torch.Generator()
+    if seed is not None:
+        generator.manual_seed(seed)
+
+    return torch.randperm(N, generator=generator)
+
+
+def flash_context(func):
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        if getattr(self, "use_flash", False):
+            assert torch.cuda.is_available(), "FlashAttention requires CUDA support"
+            bf_support = torch.cuda.get_device_capability()[0] >= 8
+            dtype = torch.bfloat16 if bf_support else torch.float16
+            with (
+                torch.autocast(device_type="cuda", dtype=dtype),
+                sdpa_kernel(SDPBackend.FLASH_ATTENTION),
+            ):
+                return func(self, *args, **kwargs)
+        else:
+            return func(self, *args, **kwargs)
+
+    return wrapper
+
+
+def maskmean(x, mask, dim):
+    x = torch.where(mask, x, 0)
+    return x.sum(dim=dim, keepdim=True) / mask.sum(dim=dim, keepdim=True)
+
+
+def maskstd(x, mask, dim=0):
+    num = mask.sum(dim=dim, keepdim=True)
+    mean = maskmean(x, mask, dim=0)
+    diffs = torch.where(mask, mean - x, 0)
+    return ((diffs**2).sum(dim=0, keepdim=True) / (num - 1)) ** 0.5
+
+
+def normalize_data(data, eval_pos=-1, dim=0, return_mean_std: bool = False):
+    X = data[:eval_pos] if eval_pos > 0 else data
+    mask = ~torch.isnan(X)
+    mean = maskmean(X, mask, dim=dim)
+    std = maskstd(X, mask, dim=dim) + 1e-6
+    data = (data - mean) / std
+    if return_mean_std:
+        return data, mean, std
+    return data
+
+
+def clip_outliers(data, eval_pos=-1, n_sigma=4, dim=0):
+    X = data[:eval_pos] if eval_pos > 0 else data
+    mask = ~torch.isnan(X)
+    mean = maskmean(X, mask, dim=dim)
+    cutoff = n_sigma * maskstd(X, mask, dim=dim)
+    mask &= cutoff >= torch.abs(X - mean)
+    cutoff = n_sigma * maskstd(X, mask, dim=dim)
+    return torch.clip(data, mean - cutoff, mean + cutoff)
+
+
+class TabDPTModel(nn.Module):
+    def __init__(
+        self,
+        dropout: float,
+        enc_cell_dim: int,
+        n_out: int,
+        regression_bin_count: int,
+        regression_bin_min: float,
+        regression_bin_max: float,
+        nhead: int,
+        nhid: int,
+        ninp: int,
+        nlayers: int,
+        num_features: int,
+        base_len: int,
+        max_len: int,
+        y_encoder_dim: int,
+        num_col_attn_layers: int = 2,
+        n_thinking_rows: int = 0,
+        use_flash: bool = True,
+        clip_sigma: float = 8.
+    ):
+        super().__init__()
+        assert regression_bin_count >= 3, "regression_bin_count must be at least 3"
+        assert regression_bin_min < regression_bin_max, "regression_bin_min must be smaller than regression_bin_max"
+        self.n_out = n_out  # number of classification outputs
+        self.regression_bin_count = regression_bin_count
+        self.regression_bin_min = regression_bin_min
+        self.regression_bin_max = regression_bin_max
+        self.ninp = ninp  # embedding dimension
+        self.nlayers = nlayers  # store for stochastic depth calculation
+        self.n_thinking_rows = n_thinking_rows
+        self.transformer_encoder = nn.ModuleList(
+            [
+                TransformerEncoderLayer(
+                    embed_dim=ninp,
+                    num_heads=nhead,
+                    ff_dim=nhid,
+                    base_len=base_len,
+                    max_len=max_len,
+                    y_encoder_dim=y_encoder_dim,
+                )
+                for _ in range(nlayers)
+            ]
+        )
+        self.num_features = num_features
+        self.encoder = nn.Linear(num_features, ninp)
+        self.enc_norm = nn.LayerNorm(ninp, elementwise_affine=False)
+        self.dropout = nn.Dropout(p=dropout)
+        self.y_encoders = nn.ModuleList(
+            [
+                nn.Sequential(
+                    nn.Linear(1, 2 * y_encoder_dim),
+                    nn.GELU(),
+                    nn.Linear(2 * y_encoder_dim, y_encoder_dim),
+                    nn.LayerNorm(y_encoder_dim, elementwise_affine=False),
+                )
+                for _ in range(nlayers)
+            ]
+        )
+        self.head = nn.Sequential(nn.Linear(ninp, nhid), nn.GELU(), nn.Linear(nhid, n_out + regression_bin_count))
+        if n_thinking_rows > 0:
+            self.thinking_embed = nn.Parameter(torch.empty(n_thinking_rows, ninp))
+            nn.init.normal_(self.thinking_embed, std=0.02)
+        self.use_flash = use_flash
+        self.clip_sigma = clip_sigma
+
+    @flash_context
+    def forward(
+        self,
+        x_src: torch.Tensor,
+        y_src: torch.Tensor,
+        num_features: torch.Tensor,
+    ) -> torch.Tensor:
+        """Forward pass of the TabDPTModel.
+        Args:
+            x_src (torch.Tensor): Input features of shape (B, T, F).
+            y_src (torch.Tensor): Target values of shape (B, T).
+            return_log_act_norms (bool): Whether to return activation norms for logging.
+        Returns:
+            torch.Tensor: Predicted values of shape (T, B, n_out + regression_bin_count).
+        """
+        x_src = x_src.transpose(0, 1)
+        y_src = y_src.transpose(0, 1)
+        eval_pos = y_src.shape[0]
+        n_think = self.n_thinking_rows
+
+        # preproces features by normalizing and clipping outliers
+        x_src = clip_outliers(x_src, -1 if self.training else eval_pos, n_sigma=self.clip_sigma)
+        x_src = normalize_data(x_src, -1 if self.training else eval_pos)
+        x_src = clip_outliers(x_src, -1 if self.training else eval_pos, n_sigma=self.clip_sigma)
+        # Replace NaN and Inf with 0 (inf can occur from division by zero in normalize_data)
+        x_src = torch.nan_to_num(x_src, nan=0.0, posinf=0.0, neginf=0.0)
+
+        x_src = self.encoder(x_src)
+        src = self.enc_norm(x_src)
+        if n_think > 0:
+            B = src.shape[1]
+            src = torch.cat([self.thinking_embed.unsqueeze(1).expand(n_think, B, -1), src], dim=0)
+
+        for l, layer in enumerate(self.transformer_encoder):
+            y_emb = self.y_encoders[l](y_src.unsqueeze(-1))
+            if n_think > 0:
+                B = y_emb.shape[1]
+                y_emb = torch.cat([y_emb.new_zeros(n_think, B, y_emb.shape[-1]), y_emb], dim=0)
+            # Layer returns residual only
+            residual = layer(src, y_emb, eval_pos + n_think)
+            src = src + residual
+
+        # final head
+        pred = self.head(src[eval_pos + n_think :].float())
+        return pred
+
+    @classmethod
+    def load(cls, model_state, config, use_flash, clip_sigma: float = 8.):
+        assert config.model.max_num_classes > 2
+        model = TabDPTModel(
+            dropout=config.training.dropout,
+            enc_cell_dim=config.model.enc_cell_dim,
+            n_out=config.model.max_num_classes,
+            regression_bin_count=config.model.regression_bin_count,
+            regression_bin_min=config.model.regression_bin_min,
+            regression_bin_max=config.model.regression_bin_max,
+            nhead=config.model.nhead,
+            nhid=config.model.ff_dim,
+            ninp=config.model.emsize,
+            nlayers=config.model.nlayers,
+            num_features=config.model.max_num_features,
+            base_len=config.model.min_eval_context,
+            max_len=config.model.max_eval_context,
+            y_encoder_dim=config.model.y_encoder_dim,
+            num_col_attn_layers=config.model.num_col_attn_layers,
+            n_thinking_rows=config.model.n_thinking_rows,
+            use_flash=use_flash,
+            clip_sigma=clip_sigma
+        )
+
+        model_state = {k.replace("_orig_mod.", ""): v for k, v in model_state.items()}
+        model_state = {k.replace("model.", ""): v for k, v in model_state.items()}
+        model.load_state_dict(model_state)
+        model.to(config.env.device)
+        model.eval()
+        return model
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model: int, eps: float = 1e-8):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Use float32 for computation to avoid bf16 underflow/NaNs
+        variance = x.float().pow(2).mean(-1, keepdim=True)
+        return (x * torch.rsqrt(variance + self.eps)).to(x.dtype) * self.weight
+
+
+class SwiGLU(nn.Module):
+    def __init__(self, d_model: int, ff_dim: int, bias: bool = False):
+        super().__init__()
+        self.up = Linear(d_model, 2 * ff_dim, bias=bias)
+        self.down = Linear(ff_dim, d_model, bias=bias)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        u, v = self.up(x).chunk(2, dim=-1)
+        return self.down(F.silu(u) * v)
+
+
+class TransformerEncoderLayer(nn.Module):
+    def __init__(
+        self,
+        embed_dim: int,
+        num_heads: int,
+        ff_dim: int,
+        base_len: int,
+        max_len: int,
+        y_encoder_dim: int,
+    ) -> None:
+        """
+        Args:
+            embed_dim (int): Dimension of the embedding.
+            num_heads (int): Number of attention heads.
+            ff_dim (int): Dimension of the feed-forward network.
+            base_len (int): Base length for attention scaling.
+            max_len (int): Maximum length for attention scaling. If equal to base_len, attention scaling is disabled.
+            y_encoder_dim (int): Dimension of per-layer y embedding; v_proj input is embed_dim + y_encoder_dim.
+        """
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.head_dim = embed_dim // num_heads
+        self.num_heads = num_heads
+        self.q_proj = nn.Linear(embed_dim, embed_dim, bias=False)
+        self.q_gate = nn.Linear(embed_dim, num_heads, bias=False)
+        self.k_proj = nn.Linear(embed_dim, embed_dim, bias=False)
+        self.v_proj = nn.Linear(embed_dim + y_encoder_dim, embed_dim, bias=False)
+        self.out_proj = nn.Linear(embed_dim, embed_dim, bias=False)
+        self.attn_norm = LayerNorm(embed_dim)
+        self.ff_norm = LayerNorm(embed_dim)
+        self.ff = SwiGLU(embed_dim, ff_dim, bias=False)
+        self.q_norm = RMSNorm(self.head_dim)
+        self.k_norm = RMSNorm(self.head_dim)
+
+        # Attention temperature stuff
+        # If base_len == max_len, disable attention scaling (kappa = 0 ensures scale is always 1.0)
+        self.disable_attention_scaling = base_len == max_len
+        dk = float(self.head_dim)
+        self.register_buffer("n0", torch.tensor(float(base_len)))
+        self.register_buffer("max_len_f", torch.tensor(float(max_len)))
+        if self.disable_attention_scaling:
+            # Set kappa to 0 to ensure scaling is always 1.0
+            self.register_buffer("kappa", torch.tensor(0.0))
+        else:
+            self.register_buffer(
+                "kappa",
+                torch.tensor((math.sqrt(dk) - 1.0) / math.log(max_len / base_len)),
+            )
+
+        # Zero-init output projections so residual branch is identity at start (attn=0, ff=0)
+        nn.init.zeros_(self.out_proj.weight)
+        nn.init.zeros_(self.q_gate.weight)
+        nn.init.zeros_(self.ff.down.weight)
+
+    def get_scale_param(self, eval_pos: int, *, device, dtype) -> torch.Tensor:
+        if self.disable_attention_scaling:
+            return torch.tensor(1.0, device=device, dtype=dtype)
+        n = torch.as_tensor(eval_pos, device=device, dtype=dtype)
+        n = torch.minimum(n, self.max_len_f.to(dtype))
+        beta = 1.0 + self.kappa.to(dtype) * torch.clamp(torch.log(n / self.n0.to(dtype)), min=0.0)
+        return beta
+
+    def forward(self, x: torch.Tensor, y: torch.Tensor, eval_pos: int) -> torch.Tensor:
+        """Compute the residual for this layer.
+
+        Args:
+            x (torch.tensor): Input tensor of shape (L, B, D).
+            y (torch.tensor): Target embedding for the context region of shape (eval_pos, B, y_encoder_dim).
+            eval_pos (int): Number of context positions (length of y and K/V).
+        Returns:
+            torch.tensor: Residual tensor to be added to input (same shape as input).
+        """
+        # switch to (B, L, D) for attention computation
+        x = x.transpose(0, 1)
+        y = y.transpose(0, 1)
+        B, L, _ = x.size()
+
+        h = self.attn_norm(x)
+        q = self.q_proj(h)
+        gate = torch.sigmoid(self.q_gate(q))
+        k = self.k_proj(h[:, :eval_pos])
+
+        h_ctx = h[:, :eval_pos]
+        v_in = torch.cat([h_ctx, y], dim=-1)
+        v = self.v_proj(v_in)
+
+        # reshape: (B, L, D) -> (B, num_heads, _, head_dim)
+        q = q.view(B, L, self.num_heads, self.head_dim).transpose(1, 2)
+        k = k.view(B, eval_pos, self.num_heads, self.head_dim).transpose(1, 2)
+        v = v.view(B, eval_pos, self.num_heads, self.head_dim).transpose(1, 2)
+
+        q, k = self.q_norm(q), self.k_norm(k)
+        beta = self.get_scale_param(eval_pos, device=q.device, dtype=q.dtype)
+        default_scale = 1.0 / math.sqrt(self.head_dim)
+        custom_scale = default_scale * beta
+
+        attn = F.scaled_dot_product_attention(q, k, v, scale=custom_scale).transpose(1, 2)
+        attn = attn * gate.unsqueeze(-1)
+        attn = self.out_proj(attn.reshape(B, L, self.num_heads * self.head_dim))
+        residual = attn + self.ff(self.ff_norm(x + attn))
+
+        # back to (L, B, D) for output
+        return residual.transpose(0, 1)

--- a/tfmplayground/models/nanotabdpt.py
+++ b/tfmplayground/models/nanotabdpt.py
@@ -1,6 +1,5 @@
-from functools import wraps
-from typing import Literal
 import math
+from functools import wraps
 
 import torch
 import torch.nn as nn
@@ -8,13 +7,7 @@ import torch.nn.functional as F
 from torch.nn import LayerNorm, Linear
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
-
-def generate_random_permutation(N, seed=None):
-    generator = torch.Generator()
-    if seed is not None:
-        generator.manual_seed(seed)
-
-    return torch.randperm(N, generator=generator)
+from tfmplayground.models.base import TabularFoundationModel
 
 
 def flash_context(func):
@@ -68,7 +61,7 @@ def clip_outliers(data, eval_pos=-1, n_sigma=4, dim=0):
     return torch.clip(data, mean - cutoff, mean + cutoff)
 
 
-class TabDPTModel(nn.Module):
+class TabDPTModel(TabularFoundationModel):
     def __init__(
         self,
         dropout: float,
@@ -87,7 +80,8 @@ class TabDPTModel(nn.Module):
         y_encoder_dim: int,
         num_col_attn_layers: int = 2,
         n_thinking_rows: int = 0,
-        use_flash: bool = True,
+        classification: bool = True,
+        use_flash: bool = False,
         clip_sigma: float = 8.
     ):
         super().__init__()
@@ -134,22 +128,15 @@ class TabDPTModel(nn.Module):
             nn.init.normal_(self.thinking_embed, std=0.02)
         self.use_flash = use_flash
         self.clip_sigma = clip_sigma
+        self.classification = classification
 
     @flash_context
-    def forward(
-        self,
-        x_src: torch.Tensor,
-        y_src: torch.Tensor,
-        num_features: torch.Tensor,
-    ) -> torch.Tensor:
-        """Forward pass of the TabDPTModel.
-        Args:
-            x_src (torch.Tensor): Input features of shape (B, T, F).
-            y_src (torch.Tensor): Target values of shape (B, T).
-            return_log_act_norms (bool): Whether to return activation norms for logging.
-        Returns:
-            torch.Tensor: Predicted values of shape (T, B, n_out + regression_bin_count).
-        """
+    def forward(self, X_train: torch.Tensor, y_train: torch.Tensor, X_test: torch.Tensor) -> torch.Tensor:
+        x_src = torch.cat([X_train, X_test], dim=1)
+        if x_src.shape[-1] < self.num_features:
+            x_src = F.pad(x_src, (0, self.num_features - x_src.shape[-1]))
+        y_src = y_train
+
         x_src = x_src.transpose(0, 1)
         y_src = y_src.transpose(0, 1)
         eval_pos = y_src.shape[0]
@@ -168,8 +155,8 @@ class TabDPTModel(nn.Module):
             B = src.shape[1]
             src = torch.cat([self.thinking_embed.unsqueeze(1).expand(n_think, B, -1), src], dim=0)
 
-        for l, layer in enumerate(self.transformer_encoder):
-            y_emb = self.y_encoders[l](y_src.unsqueeze(-1))
+        for i, layer in enumerate(self.transformer_encoder):
+            y_emb = self.y_encoders[i](y_src.unsqueeze(-1))
             if n_think > 0:
                 B = y_emb.shape[1]
                 y_emb = torch.cat([y_emb.new_zeros(n_think, B, y_emb.shape[-1]), y_emb], dim=0)
@@ -179,38 +166,10 @@ class TabDPTModel(nn.Module):
 
         # final head
         pred = self.head(src[eval_pos + n_think :].float())
-        return pred
-
-    @classmethod
-    def load(cls, model_state, config, use_flash, clip_sigma: float = 8.):
-        assert config.model.max_num_classes > 2
-        model = TabDPTModel(
-            dropout=config.training.dropout,
-            enc_cell_dim=config.model.enc_cell_dim,
-            n_out=config.model.max_num_classes,
-            regression_bin_count=config.model.regression_bin_count,
-            regression_bin_min=config.model.regression_bin_min,
-            regression_bin_max=config.model.regression_bin_max,
-            nhead=config.model.nhead,
-            nhid=config.model.ff_dim,
-            ninp=config.model.emsize,
-            nlayers=config.model.nlayers,
-            num_features=config.model.max_num_features,
-            base_len=config.model.min_eval_context,
-            max_len=config.model.max_eval_context,
-            y_encoder_dim=config.model.y_encoder_dim,
-            num_col_attn_layers=config.model.num_col_attn_layers,
-            n_thinking_rows=config.model.n_thinking_rows,
-            use_flash=use_flash,
-            clip_sigma=clip_sigma
-        )
-
-        model_state = {k.replace("_orig_mod.", ""): v for k, v in model_state.items()}
-        model_state = {k.replace("model.", ""): v for k, v in model_state.items()}
-        model.load_state_dict(model_state)
-        model.to(config.env.device)
-        model.eval()
-        return model
+        pred = pred.transpose(0, 1)
+        if self.classification:
+            return pred[..., : self.n_out]
+        return pred[..., self.n_out :]
 
 
 class RMSNorm(nn.Module):


### PR DESCRIPTION
in this pr:
- integrated [tabdpt inference model (apache-2.0, v1.2.0)](https://github.com/layer6ai-labs/TabDPT-inference/blob/9cfb05e0a6bc380ae6c99c08adc8d50dacd4f246/src/tabdpt/model.py) as `tfmplayground/models/nanotabdpt.py`
- dropped the dead checkpoint keys left in the yaml configs (will be added later)
- added E741 to ruff ignore to keep `l` var over layers
