### PR TITLE
restore memory chunking

### DIFF
--- a/tfmplayground/configs/models.py
+++ b/tfmplayground/configs/models.py
@@ -11,6 +11,7 @@ class NanoTabPFNModelConfig:
     num_attention_heads: int = 6
     mlp_hidden_size: int = 768
     num_layers: int = 6
+    num_mem_chunks: int = 1
 
 
 @dataclass

--- a/tfmplayground/models/nanotabpfn.py
+++ b/tfmplayground/models/nanotabpfn.py
@@ -1,3 +1,7 @@
+import math
+import warnings
+from collections.abc import Callable
+
 import torch
 import torch.nn.functional as F
 from torch import nn
@@ -15,6 +19,7 @@ class NanoTabPFN(nn.Module):
         mlp_hidden_size: int,
         num_layers: int,
         num_outputs: int,
+        num_mem_chunks: int = 1,
     ):
         """Initializes the feature/target encoder, transformer blocks and decoder"""
         super().__init__()
@@ -23,6 +28,7 @@ class NanoTabPFN(nn.Module):
         self.mlp_hidden_size = mlp_hidden_size
         self.num_layers = num_layers
         self.num_outputs = num_outputs
+        self.num_mem_chunks = num_mem_chunks
         self.feature_encoder = FeatureEncoder(embedding_size)
         self.target_encoder = TargetEncoder(embedding_size)
         self.transformer_blocks = nn.ModuleList()
@@ -66,7 +72,11 @@ class NanoTabPFN(nn.Module):
         src = torch.cat([x_src, y_src], 2)
         # repeatedly applies the transformer block on (B,R,C,E)
         for block in self.transformer_blocks:
-            src = block(src, train_test_split_index=train_test_split_index)
+            src = block(
+                src,
+                train_test_split_index=train_test_split_index,
+                num_mem_chunks=self.num_mem_chunks,
+            )
         # selects the target embeddings (B,num_targets,1,E)
         output = src[:, train_test_split_index:, -1, :]
         # runs the embeddings through the decoder to get
@@ -156,7 +166,7 @@ class TransformerEncoderLayer(nn.Module):
         self.norm2 = LayerNorm(embedding_size, eps=layer_norm_eps, device=device, dtype=dtype)
         self.norm3 = LayerNorm(embedding_size, eps=layer_norm_eps, device=device, dtype=dtype)
 
-    def forward(self, src: torch.Tensor, train_test_split_index: int) -> torch.Tensor:
+    def forward(self, src: torch.Tensor, train_test_split_index: int, num_mem_chunks: int = 1) -> torch.Tensor:
         """
         Takes the embeddings of the table as input and applies self-attention between features
         and self-attention between datapoints followed by a simple 2 layer MLP.
@@ -165,6 +175,9 @@ class TransformerEncoderLayer(nn.Module):
             src: (torch.Tensor) a tensor of shape (batch_size, num_rows, num_features, embedding_size)
                                 that contains all the embeddings for all the cells in the table
             train_test_split_index: (int) the length of X_train
+            num_mem_chunks: (int) Number of chunks that memory-intense operations will be split into.
+                                  Higher values use less memory but are slower. Needs to be set to 1
+                                  during training to get correct gradients.
         Returns
             (torch.Tensor) a tensor of shape (batch_size, num_rows, num_features, embedding_size)
         """
@@ -172,36 +185,80 @@ class TransformerEncoderLayer(nn.Module):
         # attention between features
         src = src.reshape(batch_size * rows_size, col_size, embedding_size)
 
-        src = self.self_attention_between_features(src, src, src)[0] + src
+        @memory_chunking(num_mem_chunks)
+        def feature_attention(x):
+            return self.self_attention_between_features(x, x, x)[0] + x
+
+        src = feature_attention(src)
         src = src.reshape(batch_size, rows_size, col_size, embedding_size)
         src = self.norm1(src)
         # attention between datapoints
         src = src.transpose(1, 2)
         src = src.reshape(batch_size * col_size, rows_size, embedding_size)
 
-        # training data attends to itself
-        src_left = self.self_attention_between_datapoints(
-            src[:, :train_test_split_index],
-            src[:, :train_test_split_index],
-            src[:, :train_test_split_index],
-        )[0]
-        # test data attends to the training data
-        src_right = self.self_attention_between_datapoints(
-            src[:, train_test_split_index:],
-            src[:, :train_test_split_index],
-            src[:, :train_test_split_index],
-        )[0]
-        src = torch.cat([src_left, src_right], dim=1) + src
+        @memory_chunking(num_mem_chunks)
+        def datapoint_attention(x):
+            # training data attends to itself
+            x_left = self.self_attention_between_datapoints(
+                x[:, :train_test_split_index],
+                x[:, :train_test_split_index],
+                x[:, :train_test_split_index],
+            )[0]
+            # test data attends to the training data
+            x_right = self.self_attention_between_datapoints(
+                x[:, train_test_split_index:],
+                x[:, :train_test_split_index],
+                x[:, :train_test_split_index],
+            )[0]
+            return torch.cat([x_left, x_right], dim=1) + x
+
+        src = datapoint_attention(src)
         src = src.reshape(batch_size, col_size, rows_size, embedding_size)
         src = src.transpose(2, 1)
         src = self.norm2(src)
         # MLP after attention
         src = src.reshape(-1, embedding_size)
 
-        src = self.linear2(F.gelu(self.linear1(src))) + src
+        @memory_chunking(num_mem_chunks)
+        def mlp(x):
+            return self.linear2(F.gelu(self.linear1(x))) + x
+
+        src = mlp(src)
         src = src.reshape(batch_size, rows_size, col_size, embedding_size)
         src = self.norm3(src)
         return src
+
+
+def memory_chunking(num_mem_chunks: int) -> callable:
+    """
+    This decorator will split the first dimension of the input into chunks and apply the wrapped function
+    to each chunk separately.
+    Args:
+        num_mem_chunks: (int) Number of chunks to split the input into, higher values use less memory but are slower.
+                          Needs to be set to 1 during training to disable chunking and get correct gradients.
+    """
+
+    def decorator(func: Callable[[torch.Tensor], torch.Tensor]) -> Callable[[torch.Tensor], torch.Tensor]:
+        def wrapper(x: torch.Tensor) -> torch.Tensor:
+            if num_mem_chunks <= 1 or x.shape[0] == 0:
+                return func(x)
+            elif torch.is_grad_enabled():
+                warnings.warn(
+                    "Memory chunking is disabled since gradient computation is enabled to avoid incorrect gradients. "
+                    "Please use `with torch.no_grad():` during inference to enable chunking.",
+                    stacklevel=2,
+                )
+                return func(x)
+            chunk_size = max(1, math.ceil(x.shape[0] / num_mem_chunks))
+            for x_split in torch.split(x, split_size_or_sections=chunk_size, dim=0):
+                x_split[:] = func(
+                    x_split
+                )  # in-place modification to save memory, will cause wrong gradients if used during training
+            return x
+
+        return wrapper
+
+    return decorator
 
 
 class Decoder(nn.Module):
@@ -239,6 +296,7 @@ class NanoTabPFNModel(NanoTabPFN, TabularFoundationModel):
             mlp_hidden_size=config.mlp_hidden_size,
             num_layers=config.num_layers,
             num_outputs=config.num_outputs,
+            num_mem_chunks=config.num_mem_chunks,
         )
         self.register_buffer("borders", torch.zeros(config.num_outputs + 1))
 

--- a/tfmplayground/models/nanotabpfn.py
+++ b/tfmplayground/models/nanotabpfn.py
@@ -171,15 +171,22 @@ class TransformerEncoderLayer(nn.Module):
         Takes the embeddings of the table as input and applies self-attention between features
         and self-attention between datapoints followed by a simple 2 layer MLP.
 
-        Args:
-            src: (torch.Tensor) a tensor of shape (batch_size, num_rows, num_features, embedding_size)
-                                that contains all the embeddings for all the cells in the table
-            train_test_split_index: (int) the length of X_train
-            num_mem_chunks: (int) Number of chunks that memory-intense operations will be split into.
-                                  Higher values use less memory but are slower. Needs to be set to 1
-                                  during training to get correct gradients.
+        Parameters
+        ----------
+        src : torch.Tensor
+            a tensor of shape (batch_size, num_rows, num_features, embedding_size)
+            that contains all the embeddings for all the cells in the table
+        train_test_split_index : int
+            the length of X_train
+        num_mem_chunks : int
+            number of chunks that memory-intense operations will be split into,
+            higher values use less memory but are slower,
+            needs to be set to 1 during training to get correct gradients
+
         Returns
-            (torch.Tensor) a tensor of shape (batch_size, num_rows, num_features, embedding_size)
+        -------
+        torch.Tensor
+            a tensor of shape (batch_size, num_rows, num_features, embedding_size)
         """
         batch_size, rows_size, col_size, embedding_size = src.shape
         # attention between features
@@ -231,11 +238,20 @@ class TransformerEncoderLayer(nn.Module):
 
 def memory_chunking(num_mem_chunks: int) -> callable:
     """
-    This decorator will split the first dimension of the input into chunks and apply the wrapped function
-    to each chunk separately.
-    Args:
-        num_mem_chunks: (int) Number of chunks to split the input into, higher values use less memory but are slower.
-                          Needs to be set to 1 during training to disable chunking and get correct gradients.
+    This decorator will split the first dimension of the input into chunks
+    and apply the wrapped function to each chunk separately.
+
+    Parameters
+    ----------
+    num_mem_chunks : int
+        number of chunks to split the input into,
+        higher values use less memory but are slower,
+        needs to be set to 1 during training to disable chunking and get correct gradients
+
+    Returns
+    -------
+    callable
+        decorator that applies wrapped function to one chunk at a time
     """
 
     def decorator(func: Callable[[torch.Tensor], torch.Tensor]) -> Callable[[torch.Tensor], torch.Tensor]:


### PR DESCRIPTION
first of the remaining todos in #43

brought back memory chunking which was deleted in #40

turns out it actually stopped chunking in fc9ff93
`num_mem_chunks` was taken and not passed to the transformer blocks
so every block used its default of 1 and the decorator returned the function unchanged
ruff did not catch it, we dont have the ARG rules on

in this pr:
- restored `memory_chunking` as it was before fc9ff93
- configified `num_mem_chunks` in `NanoTabPFNModelConfig`
- updated docstrings to numpy style

not here:
- ruff [ARG](https://docs.astral.sh/ruff/rules/#flake8-unused-arguments-arg) rules
- no tests
	- tested on cpu by [Claude Opus 5](mailto:noreply@anthropic.com)
- the other four models, may be followed in #49
