### PR TITLE
checkpoint weights only

### DIFF
--- a/tfmplayground/utils.py
+++ b/tfmplayground/utils.py
@@ -365,7 +365,7 @@ def load_model(path: str | Path) -> TabularFoundationModel:
     """
     rebuilds model from checkpoint on disk
     """
-    checkpoint = torch.load(path, map_location="cpu", weights_only=False)
+    checkpoint = torch.load(path, map_location="cpu", weights_only=True)
     model_class = getattr(models, checkpoint["model_class"])
     config_class = getattr(model_configs, checkpoint["config_class"])
     model = model_class(config=config_class(**checkpoint["model_config"]))

--- a/tfmplayground/utils.py
+++ b/tfmplayground/utils.py
@@ -365,7 +365,7 @@ def load_model(path: str | Path) -> TabularFoundationModel:
     """
     rebuilds model from checkpoint on disk
     """
-    checkpoint = torch.load(path, map_location="cpu", weights_only=True)
+    checkpoint = torch.load(path, map_location="cpu")
     model_class = getattr(models, checkpoint["model_class"])
     config_class = getattr(model_configs, checkpoint["config_class"])
     model = model_class(config=config_class(**checkpoint["model_config"]))


### PR DESCRIPTION
another of the remaining todos in #43
  follows the checkpoint loading comment in #40

  weights_only=False was introduced for including numpy random state which was removed in 555fe13

  in this pr:
  - removed `weights_only=False` 
  - default is `True` since [pytorch 2.6](https://github.com/pytorch/pytorch/releases/tag/v2.6.0#:~:text=Flip%20default%20torch.load%20to%20weights_only)

  not here:
  - checkpoint resuming #44