### PR TITLE
clarify experiment logs

### DIFF
--- a/tfmplayground/training/callbacks.py
+++ b/tfmplayground/training/callbacks.py
@@ -121,7 +121,7 @@ class ExperimentCallback(BaseLoggerCallback):
         """
         records progress of one epoch
         """
-        self.experiment.log(f"e:{epoch} l:{loss:.4f} e_t:{epoch_time:.2f}s")
+        self.experiment.log(f"epoch {epoch} | epoch time {epoch_time:.2f}s | mean loss {loss:.4f}")
 
     def close(self) -> None:
         """
@@ -182,7 +182,14 @@ class ExperimentEvaluationCallback(ExperimentCallback):
             raise ValueError("scores are empty, nothing to average")
         mean = sum(scores) / len(scores)
         self.experiment.score = mean
-        line = f"e:{epoch} l:{loss:.4f} e_t:{epoch_time:.2f}s {self.metric}:{mean:.4f} t:{len(scores)}"
+        fields = [
+            f"epoch {epoch}",
+            f"epoch time {epoch_time:.2f}s",
+            f"mean loss {loss:.4f}",
+            f"{self.metric} {mean:.4f}",
+            f"tasks {len(scores)}",
+        ]
+        line = " | ".join(fields)
         self.experiment.log(line, console=True)
 
 

--- a/tfmplayground/training/callbacks.py
+++ b/tfmplayground/training/callbacks.py
@@ -121,7 +121,7 @@ class ExperimentCallback(BaseLoggerCallback):
         """
         records progress of one epoch
         """
-        self.experiment.log(f"epoch {epoch} | epoch time {epoch_time:.2f}s | mean loss {loss:.4f}")
+        self.experiment.log(f"epoch {epoch} | epoch time {epoch_time:.2f}s | mean loss {loss:.2f}")
 
     def close(self) -> None:
         """
@@ -185,8 +185,8 @@ class ExperimentEvaluationCallback(ExperimentCallback):
         fields = [
             f"epoch {epoch}",
             f"epoch time {epoch_time:.2f}s",
-            f"mean loss {loss:.4f}",
-            f"{self.metric} {mean:.4f}",
+            f"mean loss {loss:.2f}",
+            f"{self.metric} {mean:.2f}",
             f"tasks {len(scores)}",
         ]
         line = " | ".join(fields)

--- a/tfmplayground/training/callbacks.py
+++ b/tfmplayground/training/callbacks.py
@@ -199,7 +199,7 @@ class ClassifierExperimentEvaluationCallback(ExperimentEvaluationCallback):
     """
 
     problem = "classification"
-    metric = "roc_auc"
+    metric = "mean roc auc"
 
     def evaluate(self, model: TabularFoundationModel, **kwargs) -> list[float]:
         """
@@ -217,7 +217,7 @@ class RegressorExperimentEvaluationCallback(ExperimentEvaluationCallback):
     """
 
     problem = "regression"
-    metric = "r2"
+    metric = "mean r2"
 
     def evaluate(self, model: TabularFoundationModel, **kwargs) -> list[float]:
         """

--- a/tfmplayground/training/callbacks.py
+++ b/tfmplayground/training/callbacks.py
@@ -108,7 +108,7 @@ class ExperimentCallback(BaseLoggerCallback):
         starts experiment log for this run
         """
         self.experiment = experiment
-        self.experiment.print0(f"experiment: {self.experiment.id}", console=True)
+        self.experiment.log(f"experiment: {self.experiment.id}", console=True)
 
     def on_epoch_end(
         self,
@@ -121,14 +121,14 @@ class ExperimentCallback(BaseLoggerCallback):
         """
         records progress of one epoch
         """
-        self.experiment.print0(f"e:{epoch} l:{loss:.4f} e_t:{epoch_time:.2f}s")
+        self.experiment.log(f"e:{epoch} l:{loss:.4f} e_t:{epoch_time:.2f}s")
 
     def close(self) -> None:
         """
         closes run with time it took
         """
         minutes = (datetime.now() - self.experiment.started).total_seconds() / 60
-        self.experiment.print0(f"runtime: {minutes:.2f} mins")
+        self.experiment.log(f"runtime: {minutes:.2f} mins")
 
 
 class ExperimentEvaluationCallback(ExperimentCallback):
@@ -183,7 +183,7 @@ class ExperimentEvaluationCallback(ExperimentCallback):
         mean = sum(scores) / len(scores)
         self.experiment.score = mean
         line = f"e:{epoch} l:{loss:.4f} e_t:{epoch_time:.2f}s {self.metric}:{mean:.4f} t:{len(scores)}"
-        self.experiment.print0(line, console=True)
+        self.experiment.log(line, console=True)
 
 
 class ClassifierExperimentEvaluationCallback(ExperimentEvaluationCallback):

--- a/tfmplayground/utils.py
+++ b/tfmplayground/utils.py
@@ -402,9 +402,9 @@ class Experiment:
         for label, config in configs.items():
             if config is None:
                 continue
-            self.print0(f"{label}: {type(config).__name__}")
+            self.log(f"{label}: {type(config).__name__}")
             for name, value in asdict(config).items():
-                self.print0(f"  {name}: {value}")
+                self.log(f"  {name}: {value}")
 
     def save_checkpoint(self, path: Path, model: TabularFoundationModel) -> None:
         """
@@ -433,7 +433,7 @@ class Experiment:
                 self.best_score = self.score
                 self.save_checkpoint(self.best_checkpoint_path, model)
 
-    def print0(self, s: str, console: bool = False) -> None:
+    def log(self, s: str, console: bool = False) -> None:
         """
         records one line, and shows it when asked
         """


### PR DESCRIPTION
another of the remaining todos in #43
follows the logging comments in #40

in this pr:
- renamed `print0` to `log`
- spelled out log fields

before:
```
e:1 l:0.4321 e_t:2.30s roc_auc:0.8512 t:3
```

after:
```
epoch 1 | epoch time 2.30s | mean loss 0.43 | mean roc auc 0.85 | tasks 3
```

i personally prefer shorter logs because they fit better on screen

not here:
- callback class structuring
- deleting unused callbacks
- standard python logging #44 
- ruff ARG rules #44 