### PR TITLE
fix tabfm buckets crash

### DIFF
--- a/tfmplayground/configs/models.py
+++ b/tfmplayground/configs/models.py
@@ -222,5 +222,6 @@ class TabFMRegressorConfig(TabFMModelConfig):
     """
 
     problem: str = "regression"
-    head: str = "scalar"
     is_classifier: bool = False
+    head: str = "scalar"
+    decoder_out: int = 1

--- a/tfmplayground/models/tabfm.py
+++ b/tfmplayground/models/tabfm.py
@@ -1,5 +1,5 @@
 import torch
-from tabfm.src.pytorch.model import MLP, TabFM
+from tabfm.src.pytorch.model import TabFM
 from torch import nn
 
 from tfmplayground.configs.models import TabFMClassifierConfig, TabFMRegressorConfig
@@ -48,12 +48,11 @@ class TabFMModel(TabFM, TabularFoundationModel):
         """
         rebuilds decoder for specified output size
         """
-        decoder = self.icl_predictor.decoder
-        if decoder_out == decoder.layers[-1].out_features:
+        layers = self.icl_predictor.decoder.layers
+        if decoder_out == layers[-1].out_features:
             return
-        in_dim = decoder.layers[0].in_features
-        hidden_dim = decoder.layers[0].out_features
-        self.icl_predictor.decoder = MLP(in_dim, [hidden_dim], decoder_out)
+        in_features = layers[-1].in_features
+        layers[-1] = nn.Linear(in_features, decoder_out)
 
     def forward(
         self,

--- a/tfmplayground/models/tabfm.py
+++ b/tfmplayground/models/tabfm.py
@@ -1,5 +1,5 @@
 import torch
-from tabfm.src.pytorch.model import TabFM
+from tabfm.src.pytorch.model import MLP, TabFM
 from torch import nn
 
 from tfmplayground.configs.models import TabFMClassifierConfig, TabFMRegressorConfig
@@ -33,6 +33,9 @@ class TabFMModel(TabFM, TabularFoundationModel):
             decoder_hidden=config.decoder_hidden,
             is_classifier=config.is_classifier,
         )
+        if not config.is_classifier:
+            self.rebuild_decoder(config.decoder_out)
+            self.register_buffer("borders", torch.zeros(config.decoder_out + 1))
         fourier_sigma = config.fourier_sigma
         for name in ("fourier_frequencies", "fourier_frequencies_cat"):
             # no jax checkpoint fills these so we make them random parameters
@@ -40,6 +43,17 @@ class TabFMModel(TabFM, TabularFoundationModel):
             delattr(self.cell_embedder, name)
             frequencies = torch.randn_like(zeros) * fourier_sigma
             self.cell_embedder.register_parameter(name, nn.Parameter(frequencies))
+
+    def rebuild_decoder(self, decoder_out: int) -> None:
+        """
+        rebuilds decoder for specified output size
+        """
+        decoder = self.icl_predictor.decoder
+        if decoder_out == decoder.layers[-1].out_features:
+            return
+        in_dim = decoder.layers[0].in_features
+        hidden_dim = decoder.layers[0].out_features
+        self.icl_predictor.decoder = MLP(in_dim, [hidden_dim], decoder_out)
 
     def forward(
         self,

--- a/tfmplayground/training/pretrain.py
+++ b/tfmplayground/training/pretrain.py
@@ -100,9 +100,9 @@ def default_criterion(
         num_outputs = model.borders.numel() - 1
         if head == "scalar" and num_outputs != 1:
             raise ValueError(f"{head!r} head needs 1 output, not {num_outputs}")
-        if head == "buckets" and num_outputs < 2:
-            raise ValueError(f"{head!r} head needs more than 1 output, not {num_outputs}")
         if head == "buckets":
+            if num_outputs < 2:
+                raise ValueError(f"{head!r} head needs more than 1 output, not {num_outputs}")
             model.borders = make_bucket_borders(
                 prior=prior,
                 num_buckets=num_outputs,

--- a/tfmplayground/training/pretrain.py
+++ b/tfmplayground/training/pretrain.py
@@ -97,10 +97,15 @@ def default_criterion(
         return nn.CrossEntropyLoss()
     if problem == "regression":
         head = training.criterion if training.criterion is not None else model.config.head
+        num_outputs = model.borders.numel() - 1
+        if head == "scalar" and num_outputs != 1:
+            raise ValueError(f"{head!r} head needs 1 output, not {num_outputs}")
+        if head == "buckets" and num_outputs < 2:
+            raise ValueError(f"{head!r} head needs more than 1 output, not {num_outputs}")
         if head == "buckets":
             model.borders = make_bucket_borders(
                 prior=prior,
-                num_buckets=model.borders.numel() - 1,
+                num_buckets=num_outputs,
                 batch_size=training.batch_size,
                 min_targets=training.bucket_borders_min_targets,
             ).to(device)


### PR DESCRIPTION

another of the remaining todos in #43
follows the buckets crash comment in #40

in this pr:
- added `decoder_out` to `TabFMRegressorConfig`
- registered borders for regression
- replace the last tabfm decoder layer 
- head output size check in `default_criterion`

not here:
- fitting bucket borders from the tabicl regression prior fails
