### PR TITLE
problem propagation

### DIFF
--- a/tfmplayground/training/callbacks.py
+++ b/tfmplayground/training/callbacks.py
@@ -198,7 +198,6 @@ class ClassifierExperimentEvaluationCallback(ExperimentEvaluationCallback):
     measures classifier quality with roc auc
     """
 
-    problem = "classification"
     metric = "mean roc auc"
 
     def evaluate(self, model: TabularFoundationModel, **kwargs) -> list[float]:
@@ -216,7 +215,6 @@ class RegressorExperimentEvaluationCallback(ExperimentEvaluationCallback):
     measures regressor quality with r2
     """
 
-    problem = "regression"
     metric = "mean r2"
 
     def evaluate(self, model: TabularFoundationModel, **kwargs) -> list[float]:

--- a/tfmplayground/training/pretrain.py
+++ b/tfmplayground/training/pretrain.py
@@ -159,6 +159,7 @@ def pretrainTFM(
     experiment.log_configs(model=model.config, prior=prior.config, eval=eval, training=training)
 
     trained_model = train(
+        problem=problem,
         model=model,
         prior=prior,
         criterion=criterion,

--- a/tfmplayground/training/train.py
+++ b/tfmplayground/training/train.py
@@ -17,6 +17,7 @@ from tfmplayground.utils import (
 
 
 def train(
+    problem: str,
     model: TabularFoundationModel,
     prior: Prior,
     criterion: nn.CrossEntropyLoss | ScalarMSELoss | FullSupportBarDistribution | QuantileLoss,
@@ -37,12 +38,14 @@ def train(
 
     Parameters
     ----------
+    problem : str
+        classification or regression
     model : TabularFoundationModel
         model to train
     prior : Prior
         prior that gives training tables
     criterion : nn.CrossEntropyLoss or ScalarMSELoss or FullSupportBarDistribution or QuantileLoss
-        loss criterion, and what makes run classification or regression
+        loss criterion
     epochs : int
         number of epochs to train for
     batch_size : int
@@ -72,7 +75,7 @@ def train(
     model.to(device)
     criterion = criterion.to(device)
     optimizer = schedulefree.AdamWScheduleFree(model.parameters(), lr=lr, weight_decay=0.0)
-    classification_task = isinstance(criterion, nn.CrossEntropyLoss)
+    classification_task = problem == "classification"
     regression_task = not classification_task
     batches = iter(PriorDataLoader(prior, batch_size))
 


### PR DESCRIPTION
another of the remaining todos in #43
follows the problem duplication comment in #40

in this pr:
- passed problem to train instead of inferring it from the loss class
- deleted redundant callback problem attributes

not here:
- single source for `problem`

will revisit this when we fold train into pretrain #44
