### PR TITLE
improve nanotabicl prior sampling

### DIFF
--- a/tfmplayground/configs/priors.py
+++ b/tfmplayground/configs/priors.py
@@ -13,6 +13,7 @@ class NanoTabICLPriorConfig:
     max_num_features: int = 20
     min_train_fraction: float = 0.1
     max_train_fraction: float = 0.9
+    max_row_permutations: int = 11
 
 
 @dataclass

--- a/tfmplayground/configs/priors.py
+++ b/tfmplayground/configs/priors.py
@@ -14,7 +14,6 @@ class NanoTabICLPriorConfig:
     min_train_fraction: float = 0.1
     max_train_fraction: float = 0.9
     max_cat_size: int = 100
-    max_row_permutations: int = 11
 
 
 @dataclass
@@ -26,6 +25,7 @@ class NanoTabICLClassificationPriorConfig(NanoTabICLPriorConfig):
     problem: str = "classification"
     max_num_classes: int = 10
     binary_class_probability: float = 0.5
+    max_row_permutations: int = 11
 
 
 @dataclass

--- a/tfmplayground/configs/priors.py
+++ b/tfmplayground/configs/priors.py
@@ -13,6 +13,7 @@ class NanoTabICLPriorConfig:
     max_num_features: int = 20
     min_train_fraction: float = 0.1
     max_train_fraction: float = 0.9
+    max_cat_size: int = 100
     max_row_permutations: int = 11
 
 

--- a/tfmplayground/configs/priors.py
+++ b/tfmplayground/configs/priors.py
@@ -7,11 +7,11 @@ class NanoTabICLPriorConfig:
     settings nanotabicl priors share
     """
 
-    num_datapoints_max: int = 1000
-    num_features_min: int = 2
-    num_features_max: int = 20
-    train_fraction_min: float = 0.1
-    train_fraction_max: float = 0.9
+    max_num_datapoints: int = 1000
+    min_num_features: int = 2
+    max_num_features: int = 20
+    min_train_fraction: float = 0.1
+    max_train_fraction: float = 0.9
 
 
 @dataclass

--- a/tfmplayground/configs/priors.py
+++ b/tfmplayground/configs/priors.py
@@ -25,6 +25,7 @@ class NanoTabICLClassificationPriorConfig(NanoTabICLPriorConfig):
 
     problem: str = "classification"
     max_num_classes: int = 10
+    binary_class_probability: float = 0.5
 
 
 @dataclass

--- a/tfmplayground/configs/priors.py
+++ b/tfmplayground/configs/priors.py
@@ -7,6 +7,7 @@ class NanoTabICLPriorConfig:
     settings nanotabicl priors share
     """
 
+    min_num_datapoints: int = 1000
     max_num_datapoints: int = 1000
     min_num_features: int = 2
     max_num_features: int = 20

--- a/tfmplayground/configs/priors.py
+++ b/tfmplayground/configs/priors.py
@@ -8,7 +8,8 @@ class NanoTabICLPriorConfig:
     """
 
     num_datapoints_max: int = 1000
-    num_features: int = 20
+    num_features_min: int = 2
+    num_features_max: int = 20
     train_fraction_min: float = 0.1
     train_fraction_max: float = 0.9
 

--- a/tfmplayground/priors/nanotabicl.py
+++ b/tfmplayground/priors/nanotabicl.py
@@ -391,6 +391,8 @@ class NanoTabICLPrior(Prior):
         if self.problem == "classification":
             if self.config.max_num_classes < 2:
                 raise ValueError(f"classification needs at least 2 classes, not {self.config.max_num_classes}")
+            if self.config.max_row_permutations < 1:
+                raise ValueError(f"row permutations must be at least 1, not {self.config.max_row_permutations}")
             min_num_train_rows = int(self.config.min_num_datapoints * self.config.min_train_fraction)
             max_num_train_rows = int(self.config.min_num_datapoints * self.config.max_train_fraction)
             min_num_test_rows = self.config.min_num_datapoints - max_num_train_rows

--- a/tfmplayground/priors/nanotabicl.py
+++ b/tfmplayground/priors/nanotabicl.py
@@ -388,14 +388,18 @@ class NanoTabICLPrior(Prior):
             raise ValueError("feature counts must be 1 <= min <= max")
         if not 1 < self.config.min_num_datapoints <= self.config.max_num_datapoints:
             raise ValueError("datapoint counts must be 1 < min <= max")
+        min_num_train_rows = int(self.config.min_num_datapoints * self.config.min_train_fraction)
+        max_num_train_rows = int(self.config.min_num_datapoints * self.config.max_train_fraction)
+        min_num_test_rows = self.config.min_num_datapoints - max_num_train_rows
+        if min_num_train_rows < 2:
+            raise ValueError(f"train part needs at least 2 rows, holds {min_num_train_rows} rows")
+        if min_num_test_rows < 1:
+            raise ValueError(f"test part needs at least 1 row, holds {min_num_test_rows} rows")
         if self.problem == "classification":
             if self.config.max_num_classes < 2:
                 raise ValueError(f"classification needs at least 2 classes, not {self.config.max_num_classes}")
             if self.config.max_row_permutations < 1:
                 raise ValueError(f"row permutations must be at least 1, not {self.config.max_row_permutations}")
-            min_num_train_rows = int(self.config.min_num_datapoints * self.config.min_train_fraction)
-            max_num_train_rows = int(self.config.min_num_datapoints * self.config.max_train_fraction)
-            min_num_test_rows = self.config.min_num_datapoints - max_num_train_rows
             min_num_split_rows = min(min_num_train_rows, min_num_test_rows)
             if min_num_split_rows < self.config.max_num_classes:
                 raise ValueError(f"{min_num_split_rows} train or test rows cannot hold {self.config.max_num_classes} classes")

--- a/tfmplayground/priors/nanotabicl.py
+++ b/tfmplayground/priors/nanotabicl.py
@@ -377,7 +377,7 @@ class NanoTabICLPrior(Prior):
         device: str | torch.device | None = None,
     ) -> None:
         """
-        keeps config, and checks train fractions and smallest split row count
+        keeps config, and checks config limits
         """
         self.config = config
         self.device = device if device is not None else get_default_device()

--- a/tfmplayground/priors/nanotabicl.py
+++ b/tfmplayground/priors/nanotabicl.py
@@ -411,6 +411,8 @@ class NanoTabICLPrior(Prior):
         """
         x = torch.cat([columns[f"x_{i}"] for i in range(self.num_features)], dim=-1)
         y = columns["y_0"].squeeze(-1)
+        if self.config.problem == "classification":
+            y = y.long().unique(return_inverse=True)[1]
         return x.float(), y.float()
 
     def dataset(self) -> tuple[torch.Tensor, torch.Tensor]:

--- a/tfmplayground/priors/nanotabicl.py
+++ b/tfmplayground/priors/nanotabicl.py
@@ -380,6 +380,7 @@ class NanoTabICLPrior(Prior):
         keeps config, and checks config limits
         """
         self.config = config
+        self.problem = config.problem
         self.device = device if device is not None else get_default_device()
         if not 0 < self.config.min_train_fraction <= self.config.max_train_fraction < 1:
             raise ValueError("train fractions must be 0 < min <= max < 1")
@@ -387,7 +388,7 @@ class NanoTabICLPrior(Prior):
             raise ValueError("feature counts must be 1 <= min <= max")
         if not 1 < self.config.min_num_datapoints <= self.config.max_num_datapoints:
             raise ValueError("datapoint counts must be 1 < min <= max")
-        if self.config.problem == "classification":
+        if self.problem == "classification":
             if self.config.max_num_classes < 2:
                 raise ValueError(f"classification needs at least 2 classes, not {self.config.max_num_classes}")
             min_num_train_rows = int(self.config.min_num_datapoints * self.config.min_train_fraction)
@@ -411,11 +412,13 @@ class NanoTabICLPrior(Prior):
         samples hyperparameters for next table from config limits
         """
         c = self.config
-        if c.problem == "regression":
+        self.max_cat_size = c.max_cat_size
+        if self.problem == "regression":
             self.num_classes = 0
         else:
             binary = c.max_num_classes == 2 or np.random.rand() < c.binary_class_probability
             self.num_classes = 2 if binary else int(np.random.randint(3, c.max_num_classes + 1))
+            self.max_row_permutations = c.max_row_permutations
 
     def target(self, columns: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
         """
@@ -423,7 +426,7 @@ class NanoTabICLPrior(Prior):
         """
         x = torch.cat([columns[f"x_{i}"] for i in range(self.num_features)], dim=-1)
         y = columns["y_0"].squeeze(-1)
-        if self.config.problem == "classification":
+        if self.problem == "classification":
             y = y.long().unique(return_inverse=True)[1]
         return x.float(), y.float()
 
@@ -434,14 +437,14 @@ class NanoTabICLPrior(Prior):
         self.dataset_hyperparameters()
         while True:
             columns = rand_dataset_filtered(
-                x_cat_sizes=rand_cat_sizes(self.num_features, max_cat_size=self.config.max_cat_size),
+                x_cat_sizes=rand_cat_sizes(self.num_features, max_cat_size=self.max_cat_size),
                 y_cat_sizes=[self.num_classes],
                 n_samples=self.num_datapoints,
             )
             x, y = self.target(columns)
-            if self.config.problem == "regression":
+            if self.problem == "regression":
                 return x, y
-            for _ in range(self.config.max_row_permutations):
+            for _ in range(self.max_row_permutations):
                 if len(y.unique()) == len(y[: self.sep].unique()) == len(y[self.sep :].unique()):
                     return x, y
                 perm = torch.randperm(y.shape[0])

--- a/tfmplayground/priors/nanotabicl.py
+++ b/tfmplayground/priors/nanotabicl.py
@@ -389,7 +389,7 @@ class NanoTabICLPrior(Prior):
             min_num_test_rows = self.config.min_num_datapoints - max_num_train_rows
             min_num_split_rows = min(min_num_train_rows, min_num_test_rows)
             if min_num_split_rows < self.config.max_num_classes:
-                raise ValueError(f"{min_num_split_rows} rows cannot hold {self.config.max_num_classes} classes")
+                raise ValueError(f"{min_num_split_rows} train or test rows cannot hold {self.config.max_num_classes} classes")
 
     def batch_hyperparameters(self) -> None:
         """

--- a/tfmplayground/priors/nanotabicl.py
+++ b/tfmplayground/priors/nanotabicl.py
@@ -383,7 +383,13 @@ class NanoTabICLPrior(Prior):
         self.device = device if device is not None else get_default_device()
         if not 0 < self.config.min_train_fraction <= self.config.max_train_fraction < 1:
             raise ValueError("train fractions must be 0 < min <= max < 1")
+        if not 1 <= self.config.min_num_features <= self.config.max_num_features:
+            raise ValueError("feature counts must be 1 <= min <= max")
+        if not 1 < self.config.min_num_datapoints <= self.config.max_num_datapoints:
+            raise ValueError("datapoint counts must be 1 < min <= max")
         if self.config.problem == "classification":
+            if self.config.max_num_classes < 2:
+                raise ValueError(f"classification needs at least 2 classes, not {self.config.max_num_classes}")
             min_num_train_rows = int(self.config.min_num_datapoints * self.config.min_train_fraction)
             max_num_train_rows = int(self.config.min_num_datapoints * self.config.max_train_fraction)
             min_num_test_rows = self.config.min_num_datapoints - max_num_train_rows

--- a/tfmplayground/priors/nanotabicl.py
+++ b/tfmplayground/priors/nanotabicl.py
@@ -390,9 +390,9 @@ class NanoTabICLPrior(Prior):
         """
         c = self.config
         self.num_features = int(np.random.randint(c.min_num_features, c.max_num_features + 1))
-        self.num_datapoints_max = c.max_num_datapoints
+        self.num_datapoints = int(np.random.randint(c.min_num_datapoints, c.max_num_datapoints + 1))
         fraction = np.random.uniform(c.min_train_fraction, c.max_train_fraction)
-        self.sep = int(c.max_num_datapoints * fraction)
+        self.sep = int(self.num_datapoints * fraction)
 
     def dataset_hyperparameters(self) -> None:
         """
@@ -419,7 +419,7 @@ class NanoTabICLPrior(Prior):
         """
         self.dataset_hyperparameters()
         cat_sizes = rand_cat_sizes(self.num_features)
-        columns = rand_dataset_filtered(cat_sizes, [self.num_classes], self.num_datapoints_max)
+        columns = rand_dataset_filtered(cat_sizes, [self.num_classes], self.num_datapoints)
         x, y = self.target(columns)
         return x, y
 

--- a/tfmplayground/priors/nanotabicl.py
+++ b/tfmplayground/priors/nanotabicl.py
@@ -384,7 +384,7 @@ class NanoTabICLPrior(Prior):
         if not 0 < self.config.train_fraction_min <= self.config.train_fraction_max < 1:
             raise ValueError("train fractions must be 0 < min <= max < 1")
 
-    def hyperparameters(self) -> None:
+    def batch_hyperparameters(self) -> None:
         """
         samples hyperparameters for next batch from config limits
         """
@@ -393,6 +393,12 @@ class NanoTabICLPrior(Prior):
         self.num_datapoints_max = c.num_datapoints_max
         fraction = np.random.uniform(c.train_fraction_min, c.train_fraction_max)
         self.sep = int(c.num_datapoints_max * fraction)
+
+    def dataset_hyperparameters(self) -> None:
+        """
+        samples hyperparameters for next table from config limits
+        """
+        c = self.config
         if c.problem == "regression":
             self.num_classes = 0
         else:
@@ -411,6 +417,7 @@ class NanoTabICLPrior(Prior):
         """
         samples one predictable table with random categorical sizes
         """
+        self.dataset_hyperparameters()
         cat_sizes = rand_cat_sizes(self.num_features)
         columns = rand_dataset_filtered(cat_sizes, [self.num_classes], self.num_datapoints_max)
         x, y = self.target(columns)
@@ -420,7 +427,7 @@ class NanoTabICLPrior(Prior):
         """
         stacks sampled tables into one batch, split at train test index
         """
-        self.hyperparameters()
+        self.batch_hyperparameters()
         datasets = [self.dataset() for _ in range(batch_size)]
         x = torch.stack([d[0] for d in datasets]).to(self.device)
         y = torch.stack([d[1] for d in datasets]).to(self.device)

--- a/tfmplayground/priors/nanotabicl.py
+++ b/tfmplayground/priors/nanotabicl.py
@@ -404,8 +404,7 @@ class NanoTabICLPrior(Prior):
         c = self.config
         self.num_features = int(np.random.randint(c.min_num_features, c.max_num_features + 1))
         self.num_datapoints = int(np.random.randint(c.min_num_datapoints, c.max_num_datapoints + 1))
-        fraction = np.random.uniform(c.min_train_fraction, c.max_train_fraction)
-        self.sep = int(self.num_datapoints * fraction)
+        self.sep = int(self.num_datapoints * np.random.uniform(c.min_train_fraction, c.max_train_fraction))
 
     def dataset_hyperparameters(self) -> None:
         """

--- a/tfmplayground/priors/nanotabicl.py
+++ b/tfmplayground/priors/nanotabicl.py
@@ -381,7 +381,7 @@ class NanoTabICLPrior(Prior):
         """
         self.config = config
         self.device = device if device is not None else get_default_device()
-        if not 0 < self.config.train_fraction_min <= self.config.train_fraction_max < 1:
+        if not 0 < self.config.min_train_fraction <= self.config.max_train_fraction < 1:
             raise ValueError("train fractions must be 0 < min <= max < 1")
 
     def batch_hyperparameters(self) -> None:
@@ -389,10 +389,10 @@ class NanoTabICLPrior(Prior):
         samples hyperparameters for next batch from config limits
         """
         c = self.config
-        self.num_features = int(np.random.randint(c.num_features_min, c.num_features_max + 1))
-        self.num_datapoints_max = c.num_datapoints_max
-        fraction = np.random.uniform(c.train_fraction_min, c.train_fraction_max)
-        self.sep = int(c.num_datapoints_max * fraction)
+        self.num_features = int(np.random.randint(c.min_num_features, c.max_num_features + 1))
+        self.num_datapoints_max = c.max_num_datapoints
+        fraction = np.random.uniform(c.min_train_fraction, c.max_train_fraction)
+        self.sep = int(c.max_num_datapoints * fraction)
 
     def dataset_hyperparameters(self) -> None:
         """

--- a/tfmplayground/priors/nanotabicl.py
+++ b/tfmplayground/priors/nanotabicl.py
@@ -429,7 +429,7 @@ class NanoTabICLPrior(Prior):
         self.dataset_hyperparameters()
         while True:
             columns = rand_dataset_filtered(
-                x_cat_sizes=rand_cat_sizes(self.num_features),
+                x_cat_sizes=rand_cat_sizes(self.num_features, max_cat_size=self.config.max_cat_size),
                 y_cat_sizes=[self.num_classes],
                 n_samples=self.num_datapoints,
             )

--- a/tfmplayground/priors/nanotabicl.py
+++ b/tfmplayground/priors/nanotabicl.py
@@ -389,7 +389,7 @@ class NanoTabICLPrior(Prior):
         samples hyperparameters for next batch from config limits
         """
         c = self.config
-        self.num_features = c.num_features
+        self.num_features = int(np.random.randint(c.num_features_min, c.num_features_max + 1))
         self.num_datapoints_max = c.num_datapoints_max
         fraction = np.random.uniform(c.train_fraction_min, c.train_fraction_max)
         self.sep = int(c.num_datapoints_max * fraction)

--- a/tfmplayground/priors/nanotabicl.py
+++ b/tfmplayground/priors/nanotabicl.py
@@ -377,12 +377,19 @@ class NanoTabICLPrior(Prior):
         device: str | torch.device | None = None,
     ) -> None:
         """
-        keeps config, and checks train fractions
+        keeps config, and checks train fractions and smallest split row count
         """
         self.config = config
         self.device = device if device is not None else get_default_device()
         if not 0 < self.config.min_train_fraction <= self.config.max_train_fraction < 1:
             raise ValueError("train fractions must be 0 < min <= max < 1")
+        if self.config.problem == "classification":
+            min_num_train_rows = int(self.config.min_num_datapoints * self.config.min_train_fraction)
+            max_num_train_rows = int(self.config.min_num_datapoints * self.config.max_train_fraction)
+            min_num_test_rows = self.config.min_num_datapoints - max_num_train_rows
+            min_num_split_rows = min(min_num_train_rows, min_num_test_rows)
+            if min_num_split_rows < self.config.max_num_classes:
+                raise ValueError(f"{min_num_split_rows} rows cannot hold {self.config.max_num_classes} classes")
 
     def batch_hyperparameters(self) -> None:
         """
@@ -420,10 +427,20 @@ class NanoTabICLPrior(Prior):
         samples one predictable table with random categorical sizes
         """
         self.dataset_hyperparameters()
-        cat_sizes = rand_cat_sizes(self.num_features)
-        columns = rand_dataset_filtered(cat_sizes, [self.num_classes], self.num_datapoints)
-        x, y = self.target(columns)
-        return x, y
+        while True:
+            columns = rand_dataset_filtered(
+                x_cat_sizes=rand_cat_sizes(self.num_features),
+                y_cat_sizes=[self.num_classes],
+                n_samples=self.num_datapoints,
+            )
+            x, y = self.target(columns)
+            if self.config.problem == "regression":
+                return x, y
+            for _ in range(self.config.max_row_permutations):
+                if len(y.unique()) == len(y[: self.sep].unique()) == len(y[self.sep :].unique()):
+                    return x, y
+                perm = torch.randperm(y.shape[0])
+                x, y = x[perm], y[perm]
 
     def batch(self, batch_size: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """

--- a/tfmplayground/priors/nanotabicl.py
+++ b/tfmplayground/priors/nanotabicl.py
@@ -409,7 +409,7 @@ class NanoTabICLPrior(Prior):
         if c.problem == "regression":
             self.num_classes = 0
         else:
-            binary = c.max_num_classes == 2 or np.random.rand() < 0.5
+            binary = c.max_num_classes == 2 or np.random.rand() < c.binary_class_probability
             self.num_classes = 2 if binary else int(np.random.randint(3, c.max_num_classes + 1))
 
     def target(self, columns: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:


### PR DESCRIPTION
final of the remaining todos in #43

brings prior generation closer to how tabicl does it

in this pr:
- split batch and table hyperparameter sampling
- added config knobs and checks

not here:
- configurable minimum class count
