### PR TITLE
fix wandb epoch time key

### DIFF
--- a/tfmplayground/training/callbacks.py
+++ b/tfmplayground/training/callbacks.py
@@ -91,7 +91,7 @@ class WandbLoggerCallback(BaseLoggerCallback):
             raise ImportError("wandb is not installed. Install it with: pip install wandb") from e
 
     def on_epoch_end(self, epoch: int, epoch_time: float, loss: float, model, **kwargs):
-        log_dict = {"epoch": epoch, "loss": loss, " epoch_time": epoch_time}
+        log_dict = {"epoch": epoch, "loss": loss, "epoch_time": epoch_time}
         self.wandb.log(log_dict)
 
     def close(self):


### PR DESCRIPTION
noticed while reading the callbacks

the wandb epoch time key carried a leading space, so runs logged it as " epoch_time"

in this pr:
- deleted the space

not here:
- callback class structuring #44